### PR TITLE
[1.x] Add Slots in Button and Icons

### DIFF
--- a/src/View/Components/Badge.php
+++ b/src/View/Components/Badge.php
@@ -28,8 +28,8 @@ class Badge extends Component implements Personalization
         public ?bool $outline = null,
         public ?bool $light = null,
         public ?string $style = null,
-        public ?string $right = null,
         public ?string $left = null,
+        public ?string $right = null,
     ) {
         $this->style = $this->outline ? 'outline' : ($this->light ? 'light' : 'solid');
         $this->size = $this->lg ? 'lg' : ($this->md ? 'md' : 'sm');

--- a/src/View/Components/Button/Button.php
+++ b/src/View/Components/Button/Button.php
@@ -33,6 +33,8 @@ class Button extends Component implements Personalization
         public ?bool $outline = false,
         public ?bool $light = false,
         public ?string $style = null,
+        public ?string $left = null,
+        public ?string $right = null,
     ) {
         $this->style = $this->outline ? 'outline' : ($this->light ? 'light' : 'solid');
         $this->size = $this->xs ? 'xs' : ($this->sm ? 'sm' : ($this->lg ? 'lg' : 'md'));

--- a/src/View/Components/Icon.php
+++ b/src/View/Components/Icon.php
@@ -17,6 +17,8 @@ class Icon extends Component
         public ?bool $solid = false,
         public ?bool $outline = false,
         public ?string $type = null,
+        public ?string $left = null,
+        public ?string $right = null,
     ) {
         $this->type = $this->outline ? 'outline' : ($this->solid ? 'solid' : config('tallstackui.icon'));
 

--- a/src/resources/views/components/button/button.blade.php
+++ b/src/resources/views/components/button/button.blade.php
@@ -13,11 +13,15 @@
         'rounded-md' => !$square && !$round,
         'rounded-full' => !$square && $round !== null,
     ]) }} wire:loading.attr="disabled" wire:loading.class="!cursor-wait">
-    @if ($icon && $position === 'left')
+    @if ($left)
+        {!! $left !!}
+    @elseif ($icon && $position === 'left')
         <x-icon :$icon @class([$sizes['icon'], $colors['icon']]) />
     @endif
     {{ $text ?? $slot }}
-    @if ($icon && $position === 'right')
+    @if ($right)
+        {!! $right !!}
+    @elseif ($icon && $position === 'right')
         <x-icon :$icon @class([$sizes['icon'], $colors['icon']]) />
     @endif
     @if ($loading)

--- a/src/resources/views/components/icon.blade.php
+++ b/src/resources/views/components/icon.blade.php
@@ -1,1 +1,15 @@
-<x-dynamic-component component="tallstack-ui::icon.{{ $type }}.{{ $icon ?? $name }}" {{ $attributes->class(['text-red-500' => $error]) }} />
+@php($span = $left || $right)
+
+@if ($span)
+    <span class="inline-flex items-center gap-x-1">
+@endif
+    @if ($left)
+        {!! $left !!}
+    @endif
+    <x-dynamic-component component="tallstack-ui::icon.{{ $type }}.{{ $icon ?? $name }}" {{ $attributes->class(['text-red-500' => $error]) }} />
+    @if ($right)
+        {!! $right !!}
+    @endif
+@if ($span)
+    </span>
+@endif


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [ ] Improvement
- [x] New Feature

### Description:

This PR aims to introduce the slots `$right` and `$left` into `x-button` and `x-icon`

### Demonstration:

![CleanShot 2023-11-30 at 20 49 55](https://github.com/tallstackui/tallstackui/assets/60591772/7e5fd819-8ea5-447c-a28c-017d73fb31e4)

```html
<x-icon name="users" class="w-5 h-5 text-red-500">
    <x-slot:left>
        <p class="text-2xl">Users</p>
    </x-slot:left>
</x-icon>

<x-icon name="cog" class="w-5 h-5 text-red-500">
    <x-slot:right>
        Settings
    </x-slot:right>
</x-icon>

<x-button>
    <x-slot:left>
        <x-badge text="+99" color="green" light />
    </x-slot:left>
    Test
</x-button>

<x-button>
    Test
    <x-slot:right>
        <x-badge text="+99" color="green" light />
    </x-slot:right>
</x-button>
```