### PR TITLE
[1.x] Fix: Added attribute type in form.input

### DIFF
--- a/src/View/Components/Form/Input.php
+++ b/src/View/Components/Form/Input.php
@@ -17,6 +17,7 @@ class Input extends Component implements Personalization
     public function __construct(
         public ?string $label = null,
         public ?string $id = null,
+        public ?string $type = null,
         public ?string $hint = null,
         public ?string $icon = null,
         public ?string $position = 'left',

--- a/src/View/Components/Form/Input.php
+++ b/src/View/Components/Form/Input.php
@@ -17,7 +17,6 @@ class Input extends Component implements Personalization
     public function __construct(
         public ?string $label = null,
         public ?string $id = null,
-        public ?string $type = null,
         public ?string $hint = null,
         public ?string $icon = null,
         public ?string $position = 'left',

--- a/src/resources/views/components/form/input.blade.php
+++ b/src/resources/views/components/form/input.blade.php
@@ -2,6 +2,7 @@
     $computed = $attributes->whereStartsWith('wire:model')->first();
     $error = $computed && $errors->has($computed);
     $personalize = tallstackui_personalization('form.input', $personalization());
+    $type = $attributes->get('type');
 @endphp
 
 <x-wrapper.input :$id :$computed :$error :$label :$hint :$validate>
@@ -24,7 +25,7 @@
         @if ($prefix)
             <span @class([$personalize['input.class.slot'], $personalize['error'] => $error && $validate])>{{ $prefix }}</span>
         @endif
-        <input id="{{ $id }}" type="{{ $type }}" {{ $attributes->class([
+        <input id="{{ $id }}" @if ($type) type="{{ $type }}" @endif {{ $attributes->class([
             $personalize['input.class.base'],
         ]) }}>
         @if ($suffix)

--- a/src/resources/views/components/form/input.blade.php
+++ b/src/resources/views/components/form/input.blade.php
@@ -24,7 +24,7 @@
         @if ($prefix)
             <span @class([$personalize['input.class.slot'], $personalize['error'] => $error && $validate])>{{ $prefix }}</span>
         @endif
-        <input id="{{ $id }}" {{ $attributes->class([
+        <input id="{{ $id }}" type="{{ $type }}" {{ $attributes->class([
             $personalize['input.class.base'],
         ]) }}>
         @if ($suffix)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [x] Improvement
- [ ] New Feature

### Description:

The type attribute has been added to change the type of the input e.g. Email, Number, Text, Date, Time-Local etc., and the password can also be added if the user does not want to show/hide the password


### Demonstration:

![image](https://github.com/tallstackui/tallstackui/assets/90285011/d1ea8c10-2d3e-4d1e-b08e-e48cf25fbe64)
![image](https://github.com/tallstackui/tallstackui/assets/90285011/87728755-da09-4e8a-b2f5-aa289b66fce8)

![image](https://github.com/tallstackui/tallstackui/assets/90285011/ac382801-fef3-456a-8363-29badce2883a)
![image](https://github.com/tallstackui/tallstackui/assets/90285011/a1e78b58-623d-408a-bd78-d4be30c4f5dd)

![image](https://github.com/tallstackui/tallstackui/assets/90285011/35a06006-aa85-45c7-a4e7-9ba0be1c08a7)
![image](https://github.com/tallstackui/tallstackui/assets/90285011/5d6bf574-f272-45cf-aa0d-e6c149db2d55)

![image](https://github.com/tallstackui/tallstackui/assets/90285011/c1c8eaab-c6bc-4e76-b78c-1a265a77a5bb)
![image](https://github.com/tallstackui/tallstackui/assets/90285011/32a5656a-5591-4ed3-87c1-d133885f7c74)

![image](https://github.com/tallstackui/tallstackui/assets/90285011/0b16c7e8-4766-4bdd-9750-908f7c9ecd72)
![image](https://github.com/tallstackui/tallstackui/assets/90285011/f24bf21d-e2f6-4c54-a2c9-e5288a66e59c)

### Notes:

<!-- 
Insert notes here, something like an image, gif, or whatever you think is necessary.
If this PR aims to introduce new additions, like a new component, or modify the current component styles, please, add a gif or screenshots.
-->
