### PR TITLE
PoC: Fixing Bug With Input and Icons

### DIFF
--- a/src/View/Components/Icon.php
+++ b/src/View/Components/Icon.php
@@ -2,31 +2,52 @@
 
 namespace TallStackUi\View\Components;
 
+use Exception;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
-use TallStackUi\View\Personalizations\Traits\InteractWithValidations;
+use Illuminate\View\ComponentAttributeBag;
+use Throwable;
 
 class Icon extends Component
 {
-    use InteractWithValidations;
-
     public function __construct(
-        public ?string $icon = null,
-        public ?string $name = null,
-        public bool $error = false,
+        public ?string $svg = null,
+        public ?bool $error = false,
         public ?bool $solid = false,
         public ?bool $outline = false,
-        public ?string $type = null,
         public ?string $left = null,
         public ?string $right = null,
     ) {
-        $this->type = $this->outline ? 'outline' : ($this->solid ? 'solid' : config('tallstackui.icon'));
+        //
+    }
 
-        $this->validate();
+    /**
+     * Extract the icon svg name from the attributes.
+     *
+     * @throws Throwable
+     */
+    public function extract(ComponentAttributeBag $bag): string
+    {
+        $attributes = $bag->getAttributes();
+
+        $booleans = collect($attributes)->filter(fn (mixed $value) => is_bool($value));
+
+        $icon = $booleans->keys()->first();
+
+        throw_if(! $this->svg && ! $icon, new Exception('You must set the icon using [svg] or direct attribute name.'));
+
+        throw_if(! $this->check('outline', $icon) || ! $this->check('solid', $icon), new Exception('The icon ['.$icon.'] is not a valid Heroicon icon.'));
+
+        return $icon;
     }
 
     public function render(): View
     {
         return view('tallstack-ui::components.icon');
+    }
+
+    private function check(string $type, string $icon): bool
+    {
+        return file_exists(sprintf(__DIR__.'/../../resources/views/components/icon/%s/%s.blade.php', $type, $icon));
     }
 }

--- a/src/resources/views/components/icon.blade.php
+++ b/src/resources/views/components/icon.blade.php
@@ -1,4 +1,7 @@
-@php($span = $left || $right)
+@php
+    $span = $left || $right;
+    $type = $outline ? 'outline' : ($solid ? 'solid' : config('tallstackui.icon'));
+@endphp
 
 @if ($span)
     <span class="inline-flex items-center gap-x-1">
@@ -6,7 +9,7 @@
     @if ($left)
         {!! $left !!}
     @endif
-    <x-dynamic-component component="tallstack-ui::icon.{{ $type }}.{{ $icon ?? $name }}" {{ $attributes->class(['text-red-500' => $error]) }} />
+    <x-dynamic-component component="tallstack-ui::icon.{{ $type }}.{{ $svg ?? $extract($attributes) }}" {{ $attributes->class(['text-red-500' => $error]) }} />
     @if ($right)
         {!! $right !!}
     @endif

--- a/src/resources/views/components/interaction/dialog.blade.php
+++ b/src/resources/views/components/interaction/dialog.blade.php
@@ -29,7 +29,7 @@
                  @if (!$configurations['uncloseable']) x-on:click.outside="remove()" @endif>
                 <div @class($personalize['buttons.close.wrapper'])>
                     <button x-on:click="remove()">
-                        <x-icon name="x-mark" @class($personalize['buttons.close.icon']) />
+                        <x-icon svg="x-mark" @class($personalize['buttons.close.icon']) />
                     </button>
                 </div>
                 <div>
@@ -42,27 +42,27 @@
                             'bg-secondary-100 dark:bg-dark-600' : dialog.type === 'question',
                         }">
                         <div x-show="dialog.type === 'success'">
-                            <x-icon name="check-circle"
+                            <x-icon svg="check-circle"
                                     outline
                                     @class([$personalize['icon.size'], 'text-green-600 dark:text-green-500']) />
                         </div>
                         <div x-show="dialog.type === 'error'">
-                            <x-icon name="x-circle"
+                            <x-icon svg="x-circle"
                                     outline
                                     @class([$personalize['icon.size'], 'text-red-600 dark:text-red-500']) />
                         </div>
                         <div x-show="dialog.type === 'info'">
-                            <x-icon name="information-circle"
+                            <x-icon svg="information-circle"
                                     outline
                                     @class([$personalize['icon.size'], 'text-blue-600 dark:text-blue-500']) />
                         </div>
                         <div x-show="dialog.type === 'warning'">
-                            <x-icon name="exclamation-circle"
+                            <x-icon svg="exclamation-circle"
                                     outline
                                     @class([$personalize['icon.size'], 'text-yellow-600 dark:text-yellow-500']) />
                         </div>
                         <div x-show="dialog.type === 'question'">
-                            <x-icon name="question-mark-circle"
+                            <x-icon svg="question-mark-circle"
                                     outline
                                     @class([$personalize['icon.size'], 'text-secondary-600 dark:text-secondary-500']) />
                         </div>

--- a/src/resources/views/components/interaction/toast.blade.php
+++ b/src/resources/views/components/interaction/toast.blade.php
@@ -25,27 +25,27 @@
                 <div @class($personalize['wrapper.fourth'])>
                     <div class="flex-shrink-0">
                         <div x-show="toast.type === 'success'">
-                            <x-icon name="check-circle"
+                            <x-icon svg="check-circle"
                                     outline
                                     @class([$personalize['icon.size'], 'text-green-400']) />
                         </div>
                         <div x-show="toast.type === 'error'">
-                            <x-icon name="x-circle"
+                            <x-icon svg="x-circle"
                                     outline
                                     @class([$personalize['icon.size'], 'text-red-400']) />
                         </div>
                         <div x-show="toast.type === 'info'">
-                            <x-icon name="information-circle"
+                            <x-icon svg="information-circle"
                                     outline
                                     @class([$personalize['icon.size'], 'text-blue-400']) />
                         </div>
                         <div x-show="toast.type === 'warning'">
-                            <x-icon name="exclamation-circle"
+                            <x-icon svg="exclamation-circle"
                                     outline
                                     @class([$personalize['icon.size'], 'text-yellow-400']) />
                         </div>
                         <div x-show="toast.type === 'question'">
-                            <x-icon name="question-mark-circle"
+                            <x-icon svg="question-mark-circle"
                                     outline
                                     @class([$personalize['icon.size'], 'text-secondary-400']) />
                         </div>
@@ -67,7 +67,7 @@
                     </div>
                     <div @class($personalize['buttons.close.wrapper'])>
                         <button x-on:click="hide()" type="button" @class($personalize['buttons.close.class'])>
-                            <x-icon name="x-mark" @class($personalize['buttons.close.size']) />
+                            <x-icon svg="x-mark" @class($personalize['buttons.close.size']) />
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

After review the PR #90 

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature

### Description:

After carefully reviewing the case reported by PR #90, I concluded that there is probably a bug in Laravel, the report was made here: https://github.com/laravel/framework/issues/49206

So, while there is no position from Laravel, whether it is a bug or a fix, I suggest this PR as part of resolving the issue.

### Demonstration:

The internal icon usage:

```blade
<x-icon svg="users" />
```

The doc. usage:

```blade
<x-icon users />
```

- Where "users" is the SVG name.

### Notes

- [ ] If accepted, needs to change all internal icons from `name` to `svg`.

The current tests can fail, ignore them.