### PR TITLE
[1.x] Add. Ability to Use Chevron Icons in Number Component

### DIFF
--- a/src/View/Components/Form/Number.php
+++ b/src/View/Components/Form/Number.php
@@ -21,6 +21,7 @@ class Number extends Component implements Personalization
         public ?int $min = 0,
         public ?int $max = 10,
         public ?int $delay = 2,
+        public ?bool $chevron = false,
     ) {
         $this->id ??= uniqid();
     }

--- a/src/resources/views/components/form/number.blade.php
+++ b/src/resources/views/components/form/number.blade.php
@@ -5,6 +5,11 @@
     $error = $property && $errors->has($property);
     $live = str($directive)->contains('.live');
     $personalize = tallstackui_personalization('form.number', $personalization());
+
+    $icons = [...(match ($chevron) {
+        true  => fn () => ['chevron-down', 'chevron-up'],
+        false => fn () => ['minus', 'plus']
+    })()];
 @endphp
 
 <x-wrapper.input :$id :computed="$property" :$error :$label :$hint validate>
@@ -33,7 +38,7 @@
                     type="button"
                     dusk="tallstackui_form_number_decrement"
                     @class($personalize['buttons.left.base'])>
-                <x-icon name="minus"
+                <x-icon :name="$icons[0]"
                         @class([
                             $personalize['buttons.left.size'],
                             $personalize['buttons.left.color'] => !$error,
@@ -48,7 +53,7 @@
                     type="button"
                     dusk="tallstackui_form_number_increment"
                     @class($personalize['buttons.right.base'])>
-                <x-icon name="plus"
+                <x-icon :name="$icons[1]"
                         @class([
                             $personalize['buttons.right.size'],
                             $personalize['buttons.right.color'] => !$error,


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [x] Improvement
- [ ] New Feature

### Description:

This pull request introduces the ability to use different icons in the number component by passing the `chevron` parameter.

### Demonstration:

Default:

![CleanShot 2023-12-02 at 18 32 35](https://github.com/tallstackui/tallstackui/assets/60591772/122caafa-fba8-432b-98b3-a34dce72abd6)

Chevron:

![CleanShot 2023-12-02 at 18 32 58](https://github.com/tallstackui/tallstackui/assets/60591772/b89a1b4a-faa3-4c01-a41b-cb9f02211e1a)