### PR TITLE
[1.x] Size variation in avatar, badge and tooltip

### DIFF
--- a/src/View/Components/Avatar.php
+++ b/src/View/Components/Avatar.php
@@ -21,6 +21,7 @@ class Avatar extends Component implements Personalization
         public ?Model $model = null,
         public ?string $text = null,
         public ?string $color = 'primary',
+        public ?bool $xs = null,
         public ?bool $sm = null,
         public ?bool $md = null,
         public ?bool $lg = null,
@@ -31,7 +32,7 @@ class Avatar extends Component implements Personalization
         public ?array $options = [],
     ) {
         $this->text = $this->content();
-        $this->size = $this->sm ? 'sm' : ($this->lg ? 'lg' : 'md');
+        $this->size = $this->xs ? 'xs' : ($this->sm ? 'sm' : ($this->lg ? 'lg' : 'md'));
 
         $this->colors();
     }
@@ -72,18 +73,20 @@ class Avatar extends Component implements Personalization
             'wrapper' => [
                 'class' => 'inline-flex shrink-0 items-center justify-center overflow-hidden',
                 'sizes' => [
-                    'sm' => 'w-8 h-8 text-xs',
+                    'xs' => 'w-6 h-6 text-xs',
+                    'sm' => 'w-8 h-8 text-sm',
                     'md' => 'w-12 h-12 text-md',
-                    'lg' => 'w-14 h-14 text-xl',
+                    'lg' => 'w-14 h-14 text-lg',
                 ],
             ],
             'content' => [
                 'image' => [
                     'class' => 'shrink-0 object-cover object-center text-xl',
                     'sizes' => [
+                        'xs' => 'w-6 h-6 text-xs',
                         'sm' => 'w-8 h-8 text-sm',
-                        'md' => 'w-12 h-12 text-lg',
-                        'lg' => 'w-14 h-14 text-2xl',
+                        'md' => 'w-12 h-12 text-md',
+                        'lg' => 'w-14 h-14 text-lg',
                     ],
                 ],
                 'text' => [

--- a/src/View/Components/Badge.php
+++ b/src/View/Components/Badge.php
@@ -18,6 +18,8 @@ class Badge extends Component implements Personalization
         public ?string $text = null,
         public ?string $icon = null,
         public ?string $position = 'right',
+        public ?bool $xs = null,
+        public ?bool $sm = null,
         public ?bool $md = null,
         public ?bool $lg = null,
         public ?string $color = 'primary',
@@ -32,7 +34,7 @@ class Badge extends Component implements Personalization
         public ?string $right = null,
     ) {
         $this->style = $this->outline ? 'outline' : ($this->light ? 'light' : 'solid');
-        $this->size = $this->lg ? 'lg' : ($this->md ? 'md' : 'sm');
+        $this->size = $this->xs ? 'xs' : ($this->sm ? 'sm' : ($this->lg ? 'lg' : 'md'));
         $this->position = $this->position === 'right' ? 'right' : 'left';
 
         $this->colors();
@@ -44,9 +46,10 @@ class Badge extends Component implements Personalization
             'wrapper' => [
                 'class' => 'outline-none inline-flex items-center border px-2 py-0.5 font-bold',
                 'sizes' => [
-                    'sm' => 'text-xs',
-                    'md' => 'text-sm',
-                    'lg' => 'text-md',
+                    'xs' => 'text-xs',
+                    'sm' => 'text-sm',
+                    'md' => 'text-md',
+                    'lg' => 'text-lg',
                 ],
             ],
             'icon' => 'h-3 w-3',

--- a/src/View/Components/Tooltip.php
+++ b/src/View/Components/Tooltip.php
@@ -20,6 +20,7 @@ class Tooltip extends Component implements Personalization
         public ?string $text = null,
         public ?string $icon = 'question-mark-circle',
         public string $color = 'primary',
+        public ?bool $xs = null,
         public ?bool $sm = null,
         public ?bool $md = null,
         public ?bool $lg = null,
@@ -29,7 +30,7 @@ class Tooltip extends Component implements Personalization
         public ?string $position = 'top',
         public ?string $style = null,
     ) {
-        $this->size = $this->lg ? 'lg' : ($this->md ? 'md' : 'sm');
+        $this->size = $this->xs ? 'xs' : ($this->sm ? 'sm' : ($this->lg ? 'lg' : 'md'));
         $this->style = $this->outline ? 'outline' : ($this->solid ? 'solid' : config('tallstackui.icon'));
 
         $this->validate();
@@ -41,6 +42,7 @@ class Tooltip extends Component implements Personalization
         return Arr::dot([
             'wrapper' => 'inline-flex',
             'sizes' => [
+                'xs' => 'h-4 w-4',
                 'sm' => 'h-5 w-5',
                 'md' => 'h-6 w-6',
                 'lg' => 'h-7 w-7',

--- a/tests/Feature/Components/Badge/IndexTest.php
+++ b/tests/Feature/Components/Badge/IndexTest.php
@@ -39,9 +39,10 @@ it('can render size variations', function (array $size) {
         ->assertSee('Foo bar')
         ->assertSee($class);
 })->with([
-    fn () => ['sm' => 'text-xs'],
-    fn () => ['md' => 'text-sm'],
-    fn () => ['lg' => 'text-md'],
+    fn () => ['xs' => 'text-xs'],
+    fn () => ['sm' => 'text-sm'],
+    fn () => ['md' => 'text-md'],
+    fn () => ['lg' => 'text-lg'],
 ]);
 
 it('can render outline', function () {

--- a/tests/Feature/Components/Tooltip/IndexTest.php
+++ b/tests/Feature/Components/Tooltip/IndexTest.php
@@ -2,20 +2,25 @@
 
 use Illuminate\View\ViewException;
 
-it('can render', function () {
-    $this->blade('<x-tooltip text="Foo bar" />')
-        ->assertSee('h-5 w-5');
-});
+it('can render size variations', function (array $size) {
+    $key = array_key_first($size);
+    $class = $size[$key];
 
-it('can render md', function () {
-    $this->blade('<x-tooltip text="Foo bar" md />')
-        ->assertSee('h-6 w-6');
-});
+    $component = <<<'HTML'
+    <x-tooltip text="Foo bar" {{ size }} />
+    HTML;
 
-it('can render lg', function () {
-    $this->blade('<x-tooltip text="Foo bar" lg />')
-        ->assertSee('h-7 w-7');
-});
+    $component = str_replace('{{ size }}', $key, $component);
+
+    $this->blade($component)
+        ->assertSee('Foo bar')
+        ->assertSee($class);
+})->with([
+    fn () => ['xs' => 'h-4 w-4'],
+    fn () => ['sm' => 'h-5 w-5'],
+    fn () => ['md' => 'h-6 w-6'],
+    fn () => ['lg' => 'h-7 w-7'],
+]);
 
 it('can render positioned', function (string $position) {
     $component = <<<HTML


### PR DESCRIPTION
### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [x] Enhancements
- [ ] New Feature

### Description:

This PR adds the xs variation to the avatar, badge and tooltip components

### Demonstration:

![photo_2023-12-04_16-09-11](https://github.com/tallstackui/tallstackui/assets/12436779/5a5d0f56-018b-403e-a887-2c6908f8df45)
