### PR TITLE
[1.x] Introducing Toast Expandable

### DIFF
--- a/src/Actions/AbstractInteraction.php
+++ b/src/Actions/AbstractInteraction.php
@@ -34,6 +34,7 @@ abstract class AbstractInteraction
             'type' => 'question',
             'timeout' => $this->timeout,
             'confirm' => true,
+            'expandable' => $this->expand ?? false,
         ];
 
         if (is_string($data)) {
@@ -72,6 +73,7 @@ abstract class AbstractInteraction
             'description' => $description,
             'type' => $type,
             'timeout' => $this->timeout ?? 3,
+            'expandable' => $this->expand ?? false,
             ...$params,
         ]);
     }

--- a/src/Actions/AbstractInteraction.php
+++ b/src/Actions/AbstractInteraction.php
@@ -34,7 +34,7 @@ abstract class AbstractInteraction
             'type' => 'question',
             'timeout' => $this->timeout,
             'confirm' => true,
-            'expandable' => $this->expand ?? false,
+            'expandable' => $this->expandable(),
         ];
 
         if (is_string($data)) {
@@ -73,8 +73,17 @@ abstract class AbstractInteraction
             'description' => $description,
             'type' => $type,
             'timeout' => $this->timeout ?? 3,
-            'expandable' => $this->expand ?? false,
+            'expandable' => $this->expandable(),
             ...$params,
         ]);
+    }
+
+    private function expandable(): bool
+    {
+        if (property_exists($this, 'expand')) {
+            return $this->expand ?? config('tallstackui.settings.toast.expandable', false);
+        }
+
+        return false;
     }
 }

--- a/src/Actions/Toast.php
+++ b/src/Actions/Toast.php
@@ -6,9 +6,18 @@ class Toast extends AbstractInteraction
 {
     protected string $event = 'tallstackui:toast';
 
+    protected bool $expand = false;
+
     public function error(string $title, string $description = null): AbstractInteraction
     {
         return $this->base($title, $description, 'error');
+    }
+
+    public function expandable(): AbstractInteraction
+    {
+        $this->expand = true;
+
+        return $this;
     }
 
     public function info(string $title, string $description = null): AbstractInteraction

--- a/src/Actions/Toast.php
+++ b/src/Actions/Toast.php
@@ -6,16 +6,16 @@ class Toast extends AbstractInteraction
 {
     protected string $event = 'tallstackui:toast';
 
-    protected bool $expand = false;
+    protected ?bool $expand = null;
 
     public function error(string $title, string $description = null): AbstractInteraction
     {
         return $this->base($title, $description, 'error');
     }
 
-    public function expandable(): AbstractInteraction
+    public function expandable(bool $expand = true): AbstractInteraction
     {
-        $this->expand = true;
+        $this->expand = $expand;
 
         return $this;
     }

--- a/src/View/Components/Interaction/Toast.php
+++ b/src/View/Components/Interaction/Toast.php
@@ -29,7 +29,7 @@ class Toast extends Component implements Personalization
                 'first' => 'pointer-events-none fixed inset-0 flex flex-col items-end justify-end gap-y-2 px-4 py-4',
                 'second' => 'flex w-full flex-col items-center space-y-4',
                 'third' => 'dark:bg-dark-700 pointer-events-auto w-full max-w-sm overflow-hidden rounded-xl bg-white shadow-lg ring-1 ring-black ring-opacity-5',
-                'fourth' => 'flex items-start p-4',
+                'fourth' => 'flex p-4',
             ],
             'icon' => [
                 'size' => 'h-6 w-6',
@@ -44,6 +44,12 @@ class Toast extends Component implements Personalization
                 'confirm' => 'text-primary-600 dark:text-dark-200 text-sm font-medium focus:outline-none',
                 'cancel' => 'text-red-700 dark:text-red-500 text-sm font-medium focus:outline-none',
                 'close' => [
+                    'wrapper' => 'ml-4 flex flex-shrink-0',
+                    'class' => 'inline-flex text-gray-400 focus:outline-none focus:ring-0',
+                    'size' => 'h-5 w-5',
+                ],
+                'side-wrapper' => 'ml-4 flex flex-col justify-between min-h-full',
+                'expand' => [
                     'wrapper' => 'ml-4 flex flex-shrink-0',
                     'class' => 'inline-flex text-gray-400 focus:outline-none focus:ring-0',
                     'size' => 'h-5 w-5',

--- a/src/View/Components/Interaction/Toast.php
+++ b/src/View/Components/Interaction/Toast.php
@@ -40,7 +40,10 @@ class Toast extends Component implements Personalization
                 'description' => 'dark:text-dark-400 mt-1 text-sm text-gray-700',
             ],
             'buttons' => [
-                'wrapper' => 'mt-3 flex gap-x-3',
+                'wrapper' => [
+                    'first' => 'mt-3 flex gap-x-3',
+                    'second' => 'ml-4 flex min-h-full flex-col justify-between',
+                ],
                 'confirm' => 'text-primary-600 dark:text-dark-200 text-sm font-medium focus:outline-none',
                 'cancel' => 'text-red-700 dark:text-red-500 text-sm font-medium focus:outline-none',
                 'close' => [
@@ -48,7 +51,6 @@ class Toast extends Component implements Personalization
                     'class' => 'inline-flex text-gray-400 focus:outline-none focus:ring-0',
                     'size' => 'h-5 w-5',
                 ],
-                'side-wrapper' => 'ml-4 flex flex-col justify-between min-h-full',
                 'expand' => [
                     'wrapper' => 'ml-4 flex flex-shrink-0',
                     'class' => 'inline-flex text-gray-400 focus:outline-none focus:ring-0',

--- a/src/contents/config.php
+++ b/src/contents/config.php
@@ -48,6 +48,7 @@ return [
         'toast' => [
             'z-index' => 'z-50',
             'progress' => true,
+            'expandable' => false,
             /* Alloweds: top-right, top-left, bottom-right, bottom-left */
             'position' => 'top-right',
         ],

--- a/src/resources/views/components/interaction/toast.blade.php
+++ b/src/resources/views/components/interaction/toast.blade.php
@@ -54,13 +54,13 @@
                         <p @class($personalize['content.text']) x-bind:class="{ 'font-medium' : !toast.confirm, 'font-semibold' : toast.confirm }"
                            x-text="toast.title"></p>
                         <p @class($personalize['content.description'])
-                           x-text="toast.description.substring(0, 39) + '...'"
+                           x-text="toast.description.substring(0, 30) + '...'"
                            x-show="toast.expandable"></p>
                         <p @class($personalize['content.description'])
                            x-text="toast.description"
                            x-show="!toast.expandable"></p>
                         <template x-if="toast.type === 'question'">
-                            <div @class($personalize['buttons.wrapper'])>
+                            <div @class($personalize['buttons.wrapper.first'])>
                                 <button dusk="tallstackui_toast_confirmation" @class($personalize['buttons.confirm'])
                                         x-on:click="accept(toast)"
                                         x-text="toast.options.confirm.text"></button>
@@ -70,13 +70,12 @@
                             </div>
                         </template>
                     </div>
-                    <div @class($personalize['buttons.side-wrapper'])>
+                    <div @class($personalize['buttons.wrapper.second'])>
                         <div @class($personalize['buttons.close.wrapper'])>
                             <button x-on:click="hide()" type="button" @class($personalize['buttons.close.class'])>
                                 <x-icon name="x-mark" @class($personalize['buttons.close.size']) />
                             </button>
                         </div>
-
                         <div x-show="toast.expandable" @class($personalize['buttons.expand.wrapper'])>
                             <button x-on:click="toast.expandable = !toast.expandable"
                                     type="button"

--- a/src/resources/views/components/interaction/toast.blade.php
+++ b/src/resources/views/components/interaction/toast.blade.php
@@ -77,7 +77,8 @@
                             </button>
                         </div>
                         <div x-show="toast.expandable" @class($personalize['buttons.expand.wrapper'])>
-                            <button x-on:click="toast.expandable = !toast.expandable"
+                            <button dusk="tallstackui_toast_expandable"
+                                    x-on:click="toast.expandable = !toast.expandable"
                                     type="button"
                                     @class($personalize['buttons.expand.class'])>
                                 <x-icon name="chevron-down" @class($personalize['buttons.expand.size']) />

--- a/src/resources/views/components/interaction/toast.blade.php
+++ b/src/resources/views/components/interaction/toast.blade.php
@@ -53,7 +53,12 @@
                     <div @class($personalize['content.wrapper'])>
                         <p @class($personalize['content.text']) x-bind:class="{ 'font-medium' : !toast.confirm, 'font-semibold' : toast.confirm }"
                            x-text="toast.title"></p>
-                        <p @class($personalize['content.description']) x-text="toast.description"></p>
+                        <p @class($personalize['content.description'])
+                           x-text="toast.description.substring(0, 39) + '...'"
+                           x-show="toast.expandable"></p>
+                        <p @class($personalize['content.description'])
+                           x-text="toast.description"
+                           x-show="!toast.expandable"></p>
                         <template x-if="toast.type === 'question'">
                             <div @class($personalize['buttons.wrapper'])>
                                 <button dusk="tallstackui_toast_confirmation" @class($personalize['buttons.confirm'])
@@ -65,10 +70,20 @@
                             </div>
                         </template>
                     </div>
-                    <div @class($personalize['buttons.close.wrapper'])>
-                        <button x-on:click="hide()" type="button" @class($personalize['buttons.close.class'])>
-                            <x-icon name="x-mark" @class($personalize['buttons.close.size']) />
-                        </button>
+                    <div @class($personalize['buttons.side-wrapper'])>
+                        <div @class($personalize['buttons.close.wrapper'])>
+                            <button x-on:click="hide()" type="button" @class($personalize['buttons.close.class'])>
+                                <x-icon name="x-mark" @class($personalize['buttons.close.size']) />
+                            </button>
+                        </div>
+
+                        <div x-show="toast.expandable" @class($personalize['buttons.expand.wrapper'])>
+                            <button x-on:click="toast.expandable = !toast.expandable"
+                                    type="button"
+                                    @class($personalize['buttons.expand.class'])>
+                                <x-icon name="chevron-down" @class($personalize['buttons.expand.size']) />
+                            </button>
+                        </div>
                     </div>
                 </div>
                 @if ($configurations['progress'])

--- a/tests/Browser/Interactions/Toast/IndexTest.php
+++ b/tests/Browser/Interactions/Toast/IndexTest.php
@@ -10,6 +10,33 @@ use Tests\Browser\BrowserTestCase;
 class IndexTest extends BrowserTestCase
 {
     /** @test */
+    public function can_expand(): void
+    {
+        Livewire::visit(ToastComponent::class)
+            ->assertDontSee('specimen')
+            ->click('#expand')
+            ->waitForText('Lorem Ipsum is simply')
+            ->click('@tallstackui_toast_expandable')
+            ->waitForText('specimen')
+            ->assertSee('specimen');
+    }
+
+    /** @test */
+    public function can_expand_and_not_expand_sequentially(): void
+    {
+        Livewire::visit(ToastComponent::class)
+            ->assertDontSee('specimen')
+            ->click('#expandConfirmation')
+            ->waitForText('Lorem Ipsum is simply')
+            ->click('@tallstackui_toast_expandable')
+            ->waitForText('specimen')
+            ->assertSee('specimen')
+            ->click('@tallstackui_toast_confirmation')
+            ->waitForText('chunks')
+            ->assertSee('chunks');
+    }
+
+    /** @test */
     public function can_send(): void
     {
         Livewire::visit(ToastComponent::class)
@@ -84,9 +111,36 @@ class ToastComponent extends Component
         $this->toast()->error('Foo bar error');
     }
 
+    public function expand(): void
+    {
+        $this->toast()
+            ->expandable()
+            ->success('Foo bar', 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.');
+    }
+
+    public function expandConfirmation(): void
+    {
+        $this->toast()
+            ->expandable()
+            ->confirm('Warning!', 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.', [
+                'confirm' => [
+                    'text' => 'Confirm',
+                    'method' => 'notExpandable',
+                    'params' => 'Confirmed Successfully',
+                ],
+            ]);
+    }
+
     public function info(): void
     {
         $this->toast()->info('Foo bar info');
+    }
+
+    public function notExpandable()
+    {
+        $this->toast()
+            ->expandable(false)
+            ->success('Foo bar', 'There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don\'t look even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be sure there isn\'t anything embarrassing hidden in the middle of text. All the Lorem Ipsum generators on the Internet tend to repeat predefined chunks as necessary, making this the first true generator on the Internet.');
     }
 
     public function render(): string
@@ -98,6 +152,8 @@ class ToastComponent extends Component
             <x-button id="info" wire:click="info">Info</x-button>
             <x-button id="warning" wire:click="warning">Error</x-button>
             <x-button id="confirm" wire:click="confirm">Confirm</x-button>
+            <x-button id="expand" wire:click="expand">Expand</x-button>
+            <x-button id="expandConfirmation" wire:click="expandConfirmation">Expand Confirmation</x-button>
         </div>
         HTML;
     }


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] Enhancements
- [x] New Feature

### Description:

Added the `expandable()` method to the Toast component, allowing a long message to be displayed in a reduced form and its full view to be made by clicking on the component's expand button.

### Demonstration

![CleanShot 2023-12-05 at 16 06 12](https://github.com/tallstackui/tallstackui/assets/60591772/ddef6f7a-f6c6-45ef-a1e2-92499ee04886)
