### PR TITLE
[1.x] Match Toggle's dark background to input's

### DIFF
--- a/src/View/Components/Form/Toggle.php
+++ b/src/View/Components/Form/Toggle.php
@@ -49,7 +49,7 @@ class Toggle extends Component implements Personalization
                 ],
             ],
             'background' => [
-                'class' => 'bg-secondary-200 dark:bg-dark-700 block cursor-pointer rounded-full transition duration-100 ease-in-out group-focus:ring-2 group-focus:ring-offset-2 peer-focus:ring-2 peer-focus:ring-offset-2',
+                'class' => 'bg-secondary-200 dark:bg-dark-800 block cursor-pointer rounded-full transition duration-100 ease-in-out group-focus:ring-2 group-focus:ring-offset-2 peer-focus:ring-2 peer-focus:ring-offset-2',
                 'sizes' => [
                     'xs' => 'h-3 w-5',
                     'sm' => 'h-4 w-7',


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [x] Bug Fix
- [ ] Enhancements
- [ ] New Feature

### Description:

<!-- Describe your PR, which more details as possible. -->
Fixes the background on the toggle to match the rest of the form fields.

### Demonstration:

Before:
<img width="441" alt="Screenshot 2023-12-09 at 12 49 47 am" src="https://github.com/tallstackui/tallstackui/assets/109709314/34123b44-a468-4b0f-aae7-ccdbc1239d6b">

After:
<img width="490" alt="Screenshot 2023-12-09 at 12 49 06 am" src="https://github.com/tallstackui/tallstackui/assets/109709314/4b03c77e-b94d-44d7-97cf-ca290df2469f">


### Related:

<!-- Link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->

### Notes:

<!-- 
Insert notes here, something like an image, gif, or whatever you think is necessary.
If this PR aims to introduce new additions, like a new component, or modify the current component styles, please, add a gif or screenshots.
-->
