### PR TITLE
[1.x] Introducing `invalidate` Parameter to Prevent Validation Error Messages

### DIFF
--- a/src/Foundation/Personalization/PersonalizationResources.php
+++ b/src/Foundation/Personalization/PersonalizationResources.php
@@ -128,10 +128,7 @@ class PersonalizationResources
 
     private function personalization(bool $instance = false): array|object
     {
-        // The [ignoreValidations => true] used here is a way to ignore possible validations
-        // that may exist in the component class. This is necessary because the component class
-        // is instantiated at this point, so if there are validations to be applied we would have exceptions.
-        $class = app($this->component, ['ignoreValidations' => true]);
+        $class = app($this->component);
 
         if ($instance) {
             return $class;

--- a/src/View/Components/Form/Checkbox.php
+++ b/src/View/Components/Form/Checkbox.php
@@ -26,7 +26,7 @@ class Checkbox extends BaseComponent implements Personalization
         public ?string $size = null,
         public ?string $position = 'right',
         public ?string $color = 'primary',
-        public ?bool $validate = true,
+        public ?bool $invalidate = null,
     ) {
         $this->shareable();
     }

--- a/src/View/Components/Form/Checkbox.php
+++ b/src/View/Components/Form/Checkbox.php
@@ -26,6 +26,7 @@ class Checkbox extends BaseComponent implements Personalization
         public ?string $size = null,
         public ?string $position = 'right',
         public ?string $color = 'primary',
+        public ?bool $validate = true,
     ) {
         $this->shareable();
     }

--- a/src/View/Components/Form/Color.php
+++ b/src/View/Components/Form/Color.php
@@ -22,6 +22,7 @@ class Color extends BaseComponent implements Personalization
         public ?bool $full = false,
         public Collection|array $colors = [],
         public ?string $mode = null,
+        public ?bool $validate = true,
     ) {
         $this->id ??= uniqid();
         $this->mode = $this->full ? 'full' : 'range';

--- a/src/View/Components/Form/Color.php
+++ b/src/View/Components/Form/Color.php
@@ -22,7 +22,7 @@ class Color extends BaseComponent implements Personalization
         public ?bool $full = false,
         public Collection|array $colors = [],
         public ?string $mode = null,
-        public ?bool $validate = true,
+        public ?bool $invalidate = null,
     ) {
         $this->id ??= uniqid();
         $this->mode = $this->full ? 'full' : 'range';

--- a/src/View/Components/Form/Input.php
+++ b/src/View/Components/Form/Input.php
@@ -22,7 +22,7 @@ class Input extends BaseComponent implements Personalization
         public ?string $position = 'left',
         public ?string $prefix = null,
         public ?string $suffix = null,
-        public ?bool $validate = true,
+        public ?bool $invalidate = null,
     ) {
         $this->id ??= uniqid();
         $this->position = $this->position === 'left' ? 'left' : 'right';
@@ -50,6 +50,7 @@ class Input extends BaseComponent implements Personalization
                     'right' => 'right-0 pr-3',
                 ],
                 'size' => 'h-5 w-5',
+                'color' => 'text-gray-500 dark:text-dark-400',
             ],
             'error' => $this->error(),
         ]);

--- a/src/View/Components/Form/Input.php
+++ b/src/View/Components/Form/Input.php
@@ -22,7 +22,7 @@ class Input extends BaseComponent implements Personalization
         public ?string $position = 'left',
         public ?string $prefix = null,
         public ?string $suffix = null,
-        public bool $validate = true,
+        public ?bool $validate = true,
     ) {
         $this->id ??= uniqid();
         $this->position = $this->position === 'left' ? 'left' : 'right';

--- a/src/View/Components/Form/Label.php
+++ b/src/View/Components/Form/Label.php
@@ -13,7 +13,8 @@ class Label extends BaseComponent implements Personalization
     public function __construct(
         public ?string $for = null,
         public ?string $label = null,
-        public bool $error = false,
+        public ?bool $error = false,
+        public ?bool $validate = false,
     ) {
         //
     }

--- a/src/View/Components/Form/Label.php
+++ b/src/View/Components/Form/Label.php
@@ -14,7 +14,7 @@ class Label extends BaseComponent implements Personalization
         public ?string $for = null,
         public ?string $label = null,
         public ?bool $error = false,
-        public ?bool $validate = false,
+        public ?bool $invalidate = null,
     ) {
         //
     }

--- a/src/View/Components/Form/Number.php
+++ b/src/View/Components/Form/Number.php
@@ -22,6 +22,7 @@ class Number extends BaseComponent implements Personalization
         public ?int $max = null,
         public ?int $delay = 2,
         public ?bool $chevron = false,
+        public ?bool $validate = true,
     ) {
         $this->id ??= uniqid();
     }

--- a/src/View/Components/Form/Number.php
+++ b/src/View/Components/Form/Number.php
@@ -22,7 +22,7 @@ class Number extends BaseComponent implements Personalization
         public ?int $max = null,
         public ?int $delay = 2,
         public ?bool $chevron = false,
-        public ?bool $validate = true,
+        public ?bool $invalidate = null,
     ) {
         $this->id ??= uniqid();
     }

--- a/src/View/Components/Form/Password.php
+++ b/src/View/Components/Form/Password.php
@@ -18,7 +18,7 @@ class Password extends BaseComponent implements Personalization
         public ?string $label = null,
         public ?string $id = null,
         public ?string $hint = null,
-        public ?bool $validate = true,
+        public ?bool $invalidate = null,
     ) {
         $this->id ??= uniqid();
     }

--- a/src/View/Components/Form/Password.php
+++ b/src/View/Components/Form/Password.php
@@ -14,8 +14,12 @@ class Password extends BaseComponent implements Personalization
 {
     use DefaultInputClasses;
 
-    public function __construct(public ?string $label = null, public ?string $id = null, public ?string $hint = null)
-    {
+    public function __construct(
+        public ?string $label = null,
+        public ?string $id = null,
+        public ?string $hint = null,
+        public ?bool $validate = true,
+    ) {
         $this->id ??= uniqid();
     }
 

--- a/src/View/Components/Form/Radio.php
+++ b/src/View/Components/Form/Radio.php
@@ -26,6 +26,7 @@ class Radio extends BaseComponent implements Personalization
         public ?string $size = null,
         public ?string $position = 'right',
         public ?string $color = 'primary',
+        public ?bool $validate = true,
     ) {
         $this->shareable();
     }

--- a/src/View/Components/Form/Radio.php
+++ b/src/View/Components/Form/Radio.php
@@ -26,7 +26,7 @@ class Radio extends BaseComponent implements Personalization
         public ?string $size = null,
         public ?string $position = 'right',
         public ?string $color = 'primary',
-        public ?bool $validate = true,
+        public ?bool $invalidate = null,
     ) {
         $this->shareable();
     }

--- a/src/View/Components/Form/Range.php
+++ b/src/View/Components/Form/Range.php
@@ -20,6 +20,7 @@ class Range extends BaseComponent implements Personalization
         public ?bool $lg = null,
         public ?string $size = null,
         public ?string $color = 'primary',
+        public ?bool $validate = true,
     ) {
         $this->id ??= uniqid();
         $this->size = $this->sm ? 'sm' : ($this->lg ? 'lg' : 'md');

--- a/src/View/Components/Form/Range.php
+++ b/src/View/Components/Form/Range.php
@@ -20,7 +20,7 @@ class Range extends BaseComponent implements Personalization
         public ?bool $lg = null,
         public ?string $size = null,
         public ?string $color = 'primary',
-        public ?bool $validate = true,
+        public ?bool $invalidate = null,
     ) {
         $this->id ??= uniqid();
         $this->size = $this->sm ? 'sm' : ($this->lg ? 'lg' : 'md');

--- a/src/View/Components/Form/Textarea.php
+++ b/src/View/Components/Form/Textarea.php
@@ -20,7 +20,7 @@ class Textarea extends BaseComponent implements Personalization
         public ?string $hint = null,
         public ?bool $resize = false,
         public ?bool $resizeAuto = false,
-        public ?bool $validate = true,
+        public ?bool $invalidate = null,
     ) {
         $this->id ??= uniqid();
     }

--- a/src/View/Components/Form/Textarea.php
+++ b/src/View/Components/Form/Textarea.php
@@ -20,6 +20,7 @@ class Textarea extends BaseComponent implements Personalization
         public ?string $hint = null,
         public ?bool $resize = false,
         public ?bool $resizeAuto = false,
+        public ?bool $validate = true,
     ) {
         $this->id ??= uniqid();
     }

--- a/src/View/Components/Form/Toggle.php
+++ b/src/View/Components/Form/Toggle.php
@@ -26,6 +26,7 @@ class Toggle extends BaseComponent implements Personalization
         public ?string $size = null,
         public ?string $position = 'right',
         public ?string $color = 'primary',
+        public ?bool $validate = true,
     ) {
         $this->shareable();
     }

--- a/src/View/Components/Form/Toggle.php
+++ b/src/View/Components/Form/Toggle.php
@@ -26,7 +26,7 @@ class Toggle extends BaseComponent implements Personalization
         public ?string $size = null,
         public ?string $position = 'right',
         public ?string $color = 'primary',
-        public ?bool $validate = true,
+        public ?bool $invalidate = null,
     ) {
         $this->shareable();
     }

--- a/src/View/Components/Select/Native.php
+++ b/src/View/Components/Select/Native.php
@@ -24,6 +24,7 @@ class Native extends BaseComponent implements Personalization
         public Collection|array $options = [],
         public ?string $select = null,
         public ?array $selectable = [],
+        public ?bool $invalidate = null,
     ) {
         $this->options();
     }
@@ -35,7 +36,6 @@ class Native extends BaseComponent implements Personalization
 
     public function personalization(): array
     {
-        // TODO : Deal with bg-transparent
         return Arr::dot([
             'input' => [
                 'class' => [...$this->input()],

--- a/src/View/Components/Select/Styled.php
+++ b/src/View/Components/Select/Styled.php
@@ -33,7 +33,7 @@ class Styled extends BaseComponent implements Personalization
         public ?bool $disabled = false,
         public ?bool $common = true,
         public array $placeholders = [],
-        public readonly bool $ignoreValidations = false,
+        public ?bool $invalidate = null,
     ) {
         $this->placeholders = [...__('tallstack-ui::messages.select')];
 
@@ -109,10 +109,6 @@ class Styled extends BaseComponent implements Personalization
 
         if (blank($this->placeholders['empty'])) {
             throw new InvalidArgumentException('The placeholder [empty] cannot be empty.');
-        }
-
-        if ($this->ignoreValidations) {
-            return;
         }
 
         if (filled($this->options) && filled($this->request)) {

--- a/src/View/Components/Wrapper/Input.php
+++ b/src/View/Components/Wrapper/Input.php
@@ -15,7 +15,7 @@ class Input extends BaseComponent implements Personalization
         public ?string $label = null,
         public ?string $id = null,
         public ?string $hint = null,
-        public ?bool $validate = false,
+        public ?bool $invalidate = null,
         public ?bool $password = false,
     ) {
         //

--- a/src/View/Components/Wrapper/Radio.php
+++ b/src/View/Components/Wrapper/Radio.php
@@ -17,6 +17,7 @@ class Radio extends BaseComponent implements Personalization
         public ?string $id = null,
         public ?string $position = 'left',
         public ?string $alignment = 'middle',
+        public ?bool $validate = true,
     ) {
         //
     }

--- a/src/View/Components/Wrapper/Radio.php
+++ b/src/View/Components/Wrapper/Radio.php
@@ -17,7 +17,7 @@ class Radio extends BaseComponent implements Personalization
         public ?string $id = null,
         public ?string $position = 'left',
         public ?string $alignment = 'middle',
-        public ?bool $validate = true,
+        public ?bool $invalidate = null,
     ) {
         //
     }

--- a/src/resources/views/components/form/checkbox.blade.php
+++ b/src/resources/views/components/form/checkbox.blade.php
@@ -1,11 +1,11 @@
 @php
     $personalize = $classes();
     $wire = $wireable($attributes);
-    $error = $validate && $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
     [$position, $alignment, $label] = $sloteable($label);
 @endphp
 
-<x-wrapper.radio :$id :$wire :$label :$position :$alignment>
+<x-wrapper.radio :$id :$wire :$label :$position :$alignment :$invalidate>
     <input @if ($id) id="{{ $id }}" @endif type="checkbox" {{ $attributes->class([
             $personalize['input.class'],
             $personalize['input.sizes.' . $size],

--- a/src/resources/views/components/form/checkbox.blade.php
+++ b/src/resources/views/components/form/checkbox.blade.php
@@ -1,7 +1,7 @@
 @php
     $personalize = $classes();
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = $validate && $wire && $errors->has($wire->value());
     [$position, $alignment, $label] = $sloteable($label);
 @endphp
 

--- a/src/resources/views/components/form/color.blade.php
+++ b/src/resources/views/components/form/color.blade.php
@@ -1,10 +1,10 @@
 @php
     $personalize = $classes();
     $wire = $wireable($attributes);
-    $error = $validate && $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint :$validate>
+<x-wrapper.input :$id :$wire :$label :$hint :$invalidate>
     <div x-data="tallstackui_formColor(
             @entangleable($attributes),
             @js($mode),

--- a/src/resources/views/components/form/color.blade.php
+++ b/src/resources/views/components/form/color.blade.php
@@ -1,10 +1,10 @@
 @php
     $personalize = $classes();
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = $validate && $wire && $errors->has($wire->value());
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint validate>
+<x-wrapper.input :$id :$wire :$label :$hint :$validate>
     <div x-data="tallstackui_formColor(
             @entangleable($attributes),
             @js($mode),

--- a/src/resources/views/components/form/input.blade.php
+++ b/src/resources/views/components/form/input.blade.php
@@ -1,6 +1,6 @@
 @php
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = $validate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 

--- a/src/resources/views/components/form/input.blade.php
+++ b/src/resources/views/components/form/input.blade.php
@@ -1,13 +1,13 @@
 @php
     $wire = $wireable($attributes);
-    $error = $validate && $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint :$validate>
+<x-wrapper.input :$id :$wire :$label :$hint :$invalidate>
     @if ($icon)
         <div @class([ $personalize['icon.wrapper'], $personalize['icon.paddings.' . $position]])>
-            <x-icon :$icon :$error @class([$personalize['icon.size'], 'text-secondary-500' => !$validate]) />
+            <x-icon :$icon :$error @class([$personalize['icon.size'], $personalize['icon.color'] => !$invalidate]) />
         </div>
     @endif
     <div @class([
@@ -17,14 +17,14 @@
             $personalize['input.class.color.disabled'] => $attributes->get('disabled') || $attributes->get('readonly'),
             $personalize['input.paddings.left'] => $icon && ($position === null || $position === 'left'),
             $personalize['input.paddings.right'] => $icon && $position === 'right',
-            $personalize['error'] => $error && $validate
+            $personalize['error'] => $error
         ])>
         @if ($prefix)
-            <span @class([$personalize['input.class.slot'], $personalize['error'] => $error && $validate])>{{ $prefix }}</span>
+            <span @class([$personalize['input.class.slot'], $personalize['error'] => $error])>{{ $prefix }}</span>
         @endif
         <input id="{{ $id }}" {{ $attributes->class($personalize['input.class.base']) }}>
         @if ($suffix)
-            <span @class([$personalize['input.class.slot'], $personalize['error'] => $error && $validate])>{{ $suffix }}</span>
+            <span @class([$personalize['input.class.slot'], $personalize['error'] => $error])>{{ $suffix }}</span>
         @endif
     </div>
 </x-wrapper.input>

--- a/src/resources/views/components/form/label.blade.php
+++ b/src/resources/views/components/form/label.blade.php
@@ -5,7 +5,7 @@
     if ($asterisk) $text = str($text)->beforeLast(' *');
 @endphp
 
-<label @if ($for) for="{{ $for }}" @endif @class([$personalize['text'], $personalize['error'] => $error])>
+<label @if ($for) for="{{ $for }}" @endif @class([$personalize['text'], $personalize['error'] => $error && $validate])>
     {{ $text }}
     @if ($asterisk)
         <span @class($personalize['asterisk'])>*</span>

--- a/src/resources/views/components/form/label.blade.php
+++ b/src/resources/views/components/form/label.blade.php
@@ -5,7 +5,7 @@
     if ($asterisk) $text = str($text)->beforeLast(' *');
 @endphp
 
-<label @if ($for) for="{{ $for }}" @endif @class([$personalize['text'], $personalize['error'] => $error && $validate])>
+<label @if ($for) for="{{ $for }}" @endif @class([$personalize['text'], $personalize['error'] => $error && !$invalidate])>
     {{ $text }}
     @if ($asterisk)
         <span @class($personalize['asterisk'])>*</span>

--- a/src/resources/views/components/form/number.blade.php
+++ b/src/resources/views/components/form/number.blade.php
@@ -1,11 +1,11 @@
 @php
     $icons = $icons();
     $wire = $wireable($attributes);
-    $error = $validate && $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint :$validate>
+<x-wrapper.input :$id :$wire :$label :$hint :$invalidate>
     <div @class([
             $personalize['input.class.wrapper'],
             $personalize['input.class.color.base'] => !$error,

--- a/src/resources/views/components/form/number.blade.php
+++ b/src/resources/views/components/form/number.blade.php
@@ -1,11 +1,11 @@
 @php
     $icons = $icons();
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = $validate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint validate>
+<x-wrapper.input :$id :$wire :$label :$hint :$validate>
     <div @class([
             $personalize['input.class.wrapper'],
             $personalize['input.class.color.base'] => !$error,

--- a/src/resources/views/components/form/password.blade.php
+++ b/src/resources/views/components/form/password.blade.php
@@ -1,10 +1,10 @@
 @php
     $wire = $wireable($attributes);
-    $error = $validate && $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint :$validate password>
+<x-wrapper.input :$id :$wire :$label :$hint :$invalidate password>
     <div @class([
         $personalize['input.wrapper'],
         $personalize['input.color.base'] => !$error,

--- a/src/resources/views/components/form/password.blade.php
+++ b/src/resources/views/components/form/password.blade.php
@@ -1,10 +1,10 @@
 @php
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = $validate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint validate password>
+<x-wrapper.input :$id :$wire :$label :$hint :$validate password>
     <div @class([
         $personalize['input.wrapper'],
         $personalize['input.color.base'] => !$error,

--- a/src/resources/views/components/form/radio.blade.php
+++ b/src/resources/views/components/form/radio.blade.php
@@ -1,11 +1,11 @@
 @php
     $personalize = $classes();
     $wire = $wireable($attributes);
-    $error = $validate && $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
     [$position, $alignment, $label] = $sloteable($label);
 @endphp
 
-<x-wrapper.radio :$id :$wire :$label :$position :$alignment>
+<x-wrapper.radio :$id :$wire :$label :$position :$alignment :$invalidate>
     <input @if ($id) id="{{ $id }}" @endif type="radio" {{ $attributes->class([
             $personalize['input.class'],
             $personalize['input.sizes.' . $size],

--- a/src/resources/views/components/form/radio.blade.php
+++ b/src/resources/views/components/form/radio.blade.php
@@ -1,7 +1,7 @@
 @php
     $personalize = $classes();
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = $validate && $wire && $errors->has($wire->value());
     [$position, $alignment, $label] = $sloteable($label);
 @endphp
 

--- a/src/resources/views/components/form/range.blade.php
+++ b/src/resources/views/components/form/range.blade.php
@@ -1,10 +1,10 @@
 @php
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = $validate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint validate :wrapper="$personalize['input.wrapper']">
+<x-wrapper.input :$id :$wire :$label :$hint :$validate :wrapper="$personalize['input.wrapper']">
     <input id="{{ $id }}"
            type="range"
            {{ $attributes->class([

--- a/src/resources/views/components/form/range.blade.php
+++ b/src/resources/views/components/form/range.blade.php
@@ -1,10 +1,10 @@
 @php
     $wire = $wireable($attributes);
-    $error = $validate && $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint :$validate :wrapper="$personalize['input.wrapper']">
+<x-wrapper.input :$id :$wire :$label :$hint :$invalidate :wrapper="$personalize['input.wrapper']">
     <input id="{{ $id }}"
            type="range"
            {{ $attributes->class([

--- a/src/resources/views/components/form/textarea.blade.php
+++ b/src/resources/views/components/form/textarea.blade.php
@@ -1,10 +1,10 @@
 @php
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = $validate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint validate>
+<x-wrapper.input :$id :$wire :$label :$hint :$validate>
     <div @class([
         $personalize['input.wrapper'],
         $personalize['input.color.base'] => !$error,

--- a/src/resources/views/components/form/textarea.blade.php
+++ b/src/resources/views/components/form/textarea.blade.php
@@ -1,10 +1,10 @@
 @php
     $wire = $wireable($attributes);
-    $error = $validate && $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 
-<x-wrapper.input :$id :$wire :$label :$hint :$validate>
+<x-wrapper.input :$id :$wire :$label :$hint :$invalidate>
     <div @class([
         $personalize['input.wrapper'],
         $personalize['input.color.base'] => !$error,

--- a/src/resources/views/components/form/toggle.blade.php
+++ b/src/resources/views/components/form/toggle.blade.php
@@ -1,7 +1,7 @@
 @php
     $personalize = $classes();
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = $validate && $wire && $errors->has($wire->value());
     [$position, $alignment, $label] = $sloteable($label);
 
     // We remove any bg color classes from the wrapper if there
@@ -9,7 +9,7 @@
     $personalize['wrapper.class'] = $error ? preg_replace('/\bbg-[a-zA-Z0-9-]+/', '', $personalize['background.class']) : $personalize['background.class'];
 @endphp
 
-<x-wrapper.radio :$id :$wire :$label :$position :$alignment>
+<x-wrapper.radio :$id :$wire :$label :$position :$alignment :$validate>
     <div @class($personalize['wrapper'])>
         <input @if ($id) id="{{ $id }}" @endif type="checkbox" {{ $attributes->class([
             $personalize['input.class'],

--- a/src/resources/views/components/form/toggle.blade.php
+++ b/src/resources/views/components/form/toggle.blade.php
@@ -1,7 +1,7 @@
 @php
     $personalize = $classes();
     $wire = $wireable($attributes);
-    $error = $validate && $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
     [$position, $alignment, $label] = $sloteable($label);
 
     // We remove any bg color classes from the wrapper if there
@@ -9,7 +9,7 @@
     $personalize['wrapper.class'] = $error ? preg_replace('/\bbg-[a-zA-Z0-9-]+/', '', $personalize['background.class']) : $personalize['background.class'];
 @endphp
 
-<x-wrapper.radio :$id :$wire :$label :$position :$alignment :$validate>
+<x-wrapper.radio :$id :$wire :$label :$position :$alignment :$invalidate>
     <div @class($personalize['wrapper'])>
         <input @if ($id) id="{{ $id }}" @endif type="checkbox" {{ $attributes->class([
             $personalize['input.class'],

--- a/src/resources/views/components/select/native.blade.php
+++ b/src/resources/views/components/select/native.blade.php
@@ -1,6 +1,6 @@
 @php
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 

--- a/src/resources/views/components/select/styled.blade.php
+++ b/src/resources/views/components/select/styled.blade.php
@@ -1,6 +1,6 @@
 @php
     $wire = $wireable($attributes);
-    $error = $wire && $errors->has($wire->value());
+    $error = !$invalidate && $wire && $errors->has($wire->value());
     $personalize = $classes();
 @endphp
 
@@ -90,7 +90,7 @@
                              x-model.debounce.500ms="search"
                              x-ref="search"
                              dusk="tallstackui_select_search_input"
-                             :validate="false"
+                             invalidate
                     />
                     <button type="button"
                             @class($personalize['box.button.class'])

--- a/src/resources/views/components/wrapper/input.blade.php
+++ b/src/resources/views/components/wrapper/input.blade.php
@@ -1,11 +1,11 @@
 @php
     $personalize = ['wrapper' => $attributes->get('wrapper', $classes()['wrapper'])];
-    $error = $validate && $wire && $errors->has($wire);
+    $error = !$invalidate && $wire && $errors->has($wire);
 @endphp
 
 <div>
     @if ($label)
-        <x-label for="{{ $id }}" :$label :$error :$validate/>
+        <x-label for="{{ $id }}" :$label :$error :$invalidate/>
     @endif
     <div @class($personalize['wrapper']) @if ($password) x-data="{ show : false }" @endif>
         {!! $slot !!}

--- a/src/resources/views/components/wrapper/input.blade.php
+++ b/src/resources/views/components/wrapper/input.blade.php
@@ -1,11 +1,11 @@
 @php
     $personalize = ['wrapper' => $attributes->get('wrapper', $classes()['wrapper'])];
-    $error = $wire && $errors->has($wire);
+    $error = $validate && $wire && $errors->has($wire);
 @endphp
 
 <div>
     @if ($label)
-        <x-label for="{{ $id }}" :$label :$error/>
+        <x-label for="{{ $id }}" :$label :$error :$validate/>
     @endif
     <div @class($personalize['wrapper']) @if ($password) x-data="{ show : false }" @endif>
         {!! $slot !!}
@@ -13,7 +13,7 @@
     @if ($hint && !$error)
         <x-hint :$hint/>
     @endif
-    @if ($error && $validate)
+    @if ($error)
         <x-error :$wire/>
     @endif
 </div>

--- a/src/resources/views/components/wrapper/radio.blade.php
+++ b/src/resources/views/components/wrapper/radio.blade.php
@@ -1,6 +1,6 @@
 @php
     $personalize = $classes();
-    $error = $validate && $wire && $errors->has($wire);
+    $error = !$invalidate && $wire && $errors->has($wire);
 @endphp
 
 <div>

--- a/src/resources/views/components/wrapper/radio.blade.php
+++ b/src/resources/views/components/wrapper/radio.blade.php
@@ -1,6 +1,6 @@
 @php
     $personalize = $classes();
-    $error = $wire && $errors->has($wire);
+    $error = $validate && $wire && $errors->has($wire);
 @endphp
 
 <div>

--- a/tests/Browser/Form/InputTest.php
+++ b/tests/Browser/Form/InputTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Browser\Form;
+
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+use Livewire\Livewire;
+use Tests\Browser\BrowserTestCase;
+
+class InputTest extends BrowserTestCase
+{
+    /** @test */
+    public function cannot_see_validation_error(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            #[Validate('required')]
+            public ?string $name = null;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-input dusk="input" wire:model="name" />
+                    
+                    <x-button dusk="sync" wire:click="sync">Save</x-button>
+                </div>
+                HTML;
+            }
+
+            public function sync(): void
+            {
+                $this->validate();
+            }
+        })
+            ->waitForLivewireToLoad()->type('@input', '')
+            ->waitForLivewire()->click('@sync')
+            ->waitUntilMissingText('Foo bar baz')
+            ->assertSee('The name field is required.');
+    }
+
+    /** @test */
+    public function cannot_see_validation_error_when_invalidate(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            #[Validate('required')]
+            public ?string $name = null;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-input dusk="input" wire:model="name" invalidate />
+                    
+                    <x-button dusk="sync" wire:click="sync">Save</x-button>
+                </div>
+                HTML;
+            }
+
+            public function sync(): void
+            {
+                $this->validate();
+            }
+        })
+            ->waitForLivewireToLoad()->type('@input', '')
+            ->waitForLivewire()->click('@sync')
+            ->waitUntilMissingText('Foo bar baz')
+            ->assertDontSee('The name field is required.');
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [ ] Enhancements
- [x] New Feature
### Demonstration:

```blade
<x-input ... invalidate />
```

### Description:

This pull request introduces the `invalidate` parameter to the following components:

- input
- color
- number
- password
- textarea
- checkbox
- radio
- toggle
- select.native
- select.styled

With `invalidate` parameter, the user can optionally display the validation error message.

### Related:

Relates to #149 

### Notes:

It should be doc.
