### PR TITLE
[1.x] Fixing `Color` Usage in Forms

### DIFF
--- a/src/resources/views/components/form/color.blade.php
+++ b/src/resources/views/components/form/color.blade.php
@@ -20,14 +20,18 @@
          ])>
         <div @class($personalize['selected.wrapper'])>
             <template x-if="model">
-                <button type="button" @class($personalize['selected.base']) :style="{ 'background-color': model }" x-on:click="show = !show"></button>
+                <button type="button"
+                        @class($personalize['selected.base'])
+                        :style="{ 'background-color': model }"
+                        x-on:click="show = !show"></button>
             </template>
         </div>
         <div class="w-full" wire:ignore>
             <input id="{{ $id }}" {{ $attributes->class($personalize['input.base']) }} type="text" x-model="model" x-ref="input">
         </div>
         <div class="flex items-center">
-            <button @if ($attributes->get('disabled') || $attributes->get('readonly')) disabled @endif
+            <button type="button"
+                    @if ($attributes->get('disabled') || $attributes->get('readonly')) disabled @endif
                     x-on:click="show = !show"
                     dusk="tallstackui_form_color">
                 <x-icon name="swatch" :$error @class($personalize['icon.class'])/>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [x] Bug Fix
- [ ] Enhancements
- [ ] New Feature

### Description:

This pull request aims to fix a bug when `color` is used inside forms.

### Related:

Relates to #169 