### PR TITLE
[1.x] Allowing the Usage of Duplicated `label` in Select Component

### DIFF
--- a/src/resources/views/components/select/styled.blade.php
+++ b/src/resources/views/components/select/styled.blade.php
@@ -40,7 +40,7 @@
                               }" x-text="placeholder"></span>
                     </div>
                     <div wire:ignore class="truncate" x-show="multiple && quantity > 0">
-                        <template x-for="select in selects" :key="select[selectable.label] ?? select">
+                        <template x-for="select in selects" :key="select[selectable.value] ?? select">
                             <a class="cursor-pointer">
                                 <div @class($personalize['itens.multiple.item'])>
                                     <span x-text="select[selectable.label] ?? select"></span>
@@ -106,7 +106,7 @@
                         <x-tallstack-ui::icon.others.loading @class($personalize['box.list.loading.class']) />
                     </div>
                 @endif
-                <template x-for="(option, index) in available" :key="option[selectable.label] ?? option">
+                <template x-for="(option, index) in available" :key="option[selectable.value] ?? option">
                     <li x-on:click="select(option)"
                         x-on:keypress.enter="select(option)"
                         x-bind:class="{ '{{ $personalize['box.list.item.selected'] }}': selected(option) }"

--- a/tests/Browser/Select/StyledCommonTest.php
+++ b/tests/Browser/Select/StyledCommonTest.php
@@ -219,6 +219,30 @@ class StyledCommonTest extends BrowserTestCase
     }
 
     /** @test */
+    public function can_select_multiple_with_same_label(): void
+    {
+        Livewire::visit(StyledMultipleComponentSameLabel_Common::class)
+            ->assertSee('Select an option')
+            ->assertDontSee('foo')
+            ->click('@tallstackui_select_open_close')
+            ->waitForText('foo')
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[1]')
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[2]')
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[3]')
+            ->waitForText(['baz', 'bar', 'bah'])
+            ->click('@tallstackui_select_open_close')
+            ->waitForText('foo')
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[1]')
+            ->click('@tallstackui_select_open_close')
+            ->waitForText(['baz', 'bah'])
+            ->click('@tallstackui_select_open_close')
+            ->waitForText('foo')
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[3]')
+            ->click('@tallstackui_select_open_close')
+            ->waitForText('baz');
+    }
+
+    /** @test */
     public function can_unselect(): void
     {
         Livewire::visit(StyledComponent_Common::class)
@@ -260,30 +284,6 @@ class StyledCommonTest extends BrowserTestCase
             ->click('@tallstackui_select_open_close')
             ->click('@sync')
             ->waitForText(['foo', 'bar']);
-    }
-
-    /** @test */
-    public function can_select_multiple_with_same_label(): void
-    {
-        Livewire::visit(StyledMultipleComponentSameLabel_Common::class)
-            ->assertSee('Select an option')
-            ->assertDontSee('foo')
-            ->click('@tallstackui_select_open_close')
-            ->waitForText('foo')
-            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[1]')
-            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[2]')
-            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[3]')
-            ->waitForText(['baz', 'bar', 'bah'])
-            ->click('@tallstackui_select_open_close')
-            ->waitForText('foo')
-            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[1]')
-            ->click('@tallstackui_select_open_close')
-            ->waitForText(['baz', 'bah'])
-            ->click('@tallstackui_select_open_close')
-            ->waitForText('foo')
-            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[3]')
-            ->click('@tallstackui_select_open_close')
-            ->waitForText('baz');
     }
 }
 

--- a/tests/Browser/Select/StyledCommonTest.php
+++ b/tests/Browser/Select/StyledCommonTest.php
@@ -261,6 +261,30 @@ class StyledCommonTest extends BrowserTestCase
             ->click('@sync')
             ->waitForText(['foo', 'bar']);
     }
+
+    /** @test */
+    public function can_select_multiple_with_same_label(): void
+    {
+        Livewire::visit(StyledMultipleComponentSameLabel_Common::class)
+            ->assertSee('Select an option')
+            ->assertDontSee('foo')
+            ->click('@tallstackui_select_open_close')
+            ->waitForText('foo')
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[1]')
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[2]')
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[3]')
+            ->waitForText(['baz', 'bar', 'bah'])
+            ->click('@tallstackui_select_open_close')
+            ->waitForText('foo')
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[1]')
+            ->click('@tallstackui_select_open_close')
+            ->waitForText(['baz', 'bah'])
+            ->click('@tallstackui_select_open_close')
+            ->waitForText('foo')
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div/ul/li[3]')
+            ->click('@tallstackui_select_open_close')
+            ->waitForText('baz');
+    }
 }
 
 class StyledComponent_Common extends Component
@@ -358,6 +382,32 @@ class StyledMultipleComponent_Common extends Component
     public function sync(): void
     {
         // ...
+    }
+}
+
+class StyledMultipleComponentSameLabel_Common extends Component
+{
+    public ?array $array = null;
+
+    public function render(): string
+    {
+        return <<<'HTML'
+        <div>
+            {{ implode(',', $array ?? []) }}
+
+            <x-select.styled wire:model.live="array"
+                             label="Select"
+                             hint="Select"
+                             :options="[
+                                ['label' => 'foo', 'value' => 'bar'],
+                                ['label' => 'foo', 'value' => 'baz'],
+                                ['label' => 'foo', 'value' => 'bah'],
+                             ]"
+                             select="label:label|value:value"
+                             multiple
+            />
+        </div>
+        HTML;
     }
 }
 


### PR DESCRIPTION
User value instead of label for select :key

<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [x] Bug Fix
- [ ] Enhancements
- [ ] New Feature

### Description:
In some cases, when using :key with the label attribute in an x-for loop, it can result in errors such as Alpine Warning: "x-for ":key" is undefined or an invalid template."


Using the actual value of what's selected works better to make sure each thing in the loop is identified correctly.

![image](https://github.com/tallstackui/tallstackui/assets/496651/c04cfa7c-d719-480d-887e-4248044fab77)


### Demonstration:



### Related:



### Notes:

