### PR TITLE
[1.x] Avoid Display `cancel` Button in Dialog & Toast When Not Defined

### DIFF
--- a/src/Actions/Traits/InteractWithConfirmation.php
+++ b/src/Actions/Traits/InteractWithConfirmation.php
@@ -4,6 +4,8 @@ namespace TallStackUi\Actions\Traits;
 
 use Exception;
 use TallStackUi\Actions\AbstractInteraction;
+use TallStackUi\Actions\Dialog;
+use TallStackUi\Actions\Toast;
 
 /**
  * @internal This trait is not meant to be used directly.
@@ -12,8 +14,17 @@ trait InteractWithConfirmation
 {
     public function confirm(string|array $data, ?string $description = null, ?array $options = null): AbstractInteraction
     {
+        $class = [
+            Dialog::class => 'dialog',
+            Toast::class => 'toast',
+        ][static::class];
+
         if ((is_string($data) && ! $options) || (is_array($data) && ! isset($data['options']))) {
-            throw new Exception('You must provide options for the interaction');
+            throw new Exception("You must provide options for the [$class] interaction");
+        }
+
+        if (! isset($options['confirm']['method'])) {
+            throw new Exception("You must provide a method for the [$class] confirm button");
         }
 
         [$confirm, $cancel] = $this->messages();

--- a/src/resources/views/components/interaction/dialog.blade.php
+++ b/src/resources/views/components/interaction/dialog.blade.php
@@ -75,7 +75,7 @@
                     </div>
                 </div>
                 <div @class($personalize['buttons.wrapper'])>
-                    <div x-show="dialog.type === 'question' && dialog.options?.cancel">
+                    <div x-show="dialog.type === 'question' && dialog.options.cancel?.method">
                         <x-button :color="$colors['cancel']"
                                   class="w-full text-sm"
                                   x-on:click="reject(dialog, $el)"
@@ -85,7 +85,7 @@
                     </div>
                     <button @class($personalize['buttons.confirm']) x-bind:class="{
                             'sm:w-auto' : dialog.type === 'question',
-                            'col-span-full' : dialog.type !== 'question' || dialog.type === 'question' && !dialog.options?.cancel,
+                            'col-span-full' : dialog.type !== 'question' || dialog.type === 'question' && !dialog.options.cancel?.method,
                             '{{ $colors['confirm']['success'] }}': dialog.type === 'success',
                             '{{ $colors['confirm']['error'] }}': dialog.type === 'error',
                             '{{ $colors['confirm']['info'] }}': dialog.type === 'info',

--- a/src/resources/views/components/interaction/toast.blade.php
+++ b/src/resources/views/components/interaction/toast.blade.php
@@ -64,7 +64,7 @@
                                 <button dusk="tallstackui_toast_confirmation" @class($personalize['buttons.confirm'])
                                         x-on:click="accept(toast)"
                                         x-text="toast.options.confirm.text"></button>
-                                <div x-show="toast.options.cancel">
+                                <div x-show="toast.options.cancel?.method">
                                     <button dusk="tallstackui_toast_rejection" @class($personalize['buttons.cancel'])
                                             x-on:click="reject(toast)"
                                             x-text="toast.options.cancel?.text"></button>

--- a/tests/Browser/Interactions/Dialog/IndexTest.php
+++ b/tests/Browser/Interactions/Dialog/IndexTest.php
@@ -266,6 +266,41 @@ class IndexTest extends BrowserTestCase
             ->waitForText('Foo bar success')
             ->assertSee('Foo bar success');
     }
+
+    /** @test */
+    public function cannot_see_cancellation_if_it_was_not_defined(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            use Interactions;
+
+            public function confirm(): void
+            {
+                $this->dialog()->confirm('Foo bar confirmation', 'Foo bar confirmation description', [
+                    'confirm' => [
+                        'text' => 'Confirm',
+                        'method' => 'confirmed',
+                        'params' => 'Foo bar confirmed foo',
+                    ],
+                ]);
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-button dusk="confirm" wire:click="confirm">Confirm</x-button>
+                </div>
+                HTML;
+            }
+        })
+            ->assertDontSee('Foo bar confirmation')
+            ->click('@confirm')
+            ->waitForText('Foo bar confirmation')
+            ->assertSee('Foo bar confirmation')
+            ->assertSee('Foo bar confirmation description')
+            ->assertDontSee('Cancelled');
+    }
 }
 
 class DialogComponent extends Component

--- a/tests/Browser/Interactions/Toast/IndexTest.php
+++ b/tests/Browser/Interactions/Toast/IndexTest.php
@@ -287,6 +287,41 @@ class IndexTest extends BrowserTestCase
             ->click('@tallstackui_toast_confirmation')
             ->waitForText('Foo bar confirmed foo');
     }
+
+    /** @test */
+    public function cannot_see_cancellation_if_it_was_not_defined(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            use Interactions;
+
+            public function confirm(): void
+            {
+                $this->toast()->confirm('Foo bar confirmation', 'Foo bar confirmation description', [
+                    'confirm' => [
+                        'text' => 'Confirm',
+                        'method' => 'confirmed',
+                        'params' => 'Foo bar confirmed foo',
+                    ],
+                ]);
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-button dusk="confirm" wire:click="confirm">Confirm</x-button>
+                </div>
+                HTML;
+            }
+        })
+            ->assertDontSee('Foo bar confirmation')
+            ->click('@confirm')
+            ->waitForText('Foo bar confirmation')
+            ->assertSee('Foo bar confirmation')
+            ->assertSee('Foo bar confirmation description')
+            ->assertDontSee('Cancelled');
+    }
 }
 
 class ToastComponent extends Component


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [x] Enhancements
- [ ] New Feature

### Description:

This pull request aims to hide the `cancel` button when not explicitly defined in Toast & Dialog.