### PR TITLE
[1.x] Bugfix for Table Pagination Element & Add. `simple-pagination` Option

### DIFF
--- a/src/Foundation/Support/BladeDirectives.php
+++ b/src/Foundation/Support/BladeDirectives.php
@@ -26,7 +26,7 @@ class BladeDirectives
 
         // The objective of this directive is to allow interaction with contents of the table
         // component. The  concept was taken from konradkalemba/blade-components-scoped-slots.
-        Blade::directive('column', function (mixed $expression): string {
+        Blade::directive('interact', function (mixed $expression): string {
             $directive = array_map('trim', preg_split('/,(?![^(]*[)])/', $expression));
             $directive[1] ??= ''; // Prevents the error "Undefined key: 1" when the parameter is not defined.
 
@@ -42,7 +42,7 @@ class BladeDirectives
             return "<?php \$__env->slot({$name}, function({$arguments}) use ({$parameters}) { ?>";
         });
 
-        Blade::directive('endcolumn', function (): string {
+        Blade::directive('endinteract', function (): string {
             return '<?php }); ?>';
         });
 

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -16,6 +16,7 @@ use TallStackUi\Foundation\Personalization\Contracts\Personalization;
 class Table extends BaseComponent implements Personalization
 {
     public function __construct(
+        public ?string $id = null,
         public Collection|array $headers = [],
         public LengthAwarePaginator|Paginator|Collection|array $rows = [],
         public ?bool $headerless = false,
@@ -30,6 +31,7 @@ class Table extends BaseComponent implements Personalization
         public ?bool $paginate = false,
         #[SkipDebug]
         public ?string $paginator = 'tallstack-ui::components.table.paginators',
+        public ?bool $simplePagination = false,
         #[SkipDebug]
         public array|string $target = [],
     ) {
@@ -50,6 +52,12 @@ class Table extends BaseComponent implements Personalization
 
         $this->filters['quantity'] ??= null;
         $this->filters['search'] ??= null;
+
+        if ($this->id !== null) {
+            $this->id = str($this->id)->lower()
+                ->slug()
+                ->value();
+        }
     }
 
     public function blade(): View
@@ -115,6 +123,10 @@ class Table extends BaseComponent implements Personalization
 
         if (blank($messages['search'] ?? null)) {
             throw new Exception('The table [search] message cannot be empty.');
+        }
+
+        if ($this->paginate && blank($this->id)) {
+            throw new Exception('The table [id] property is required when [paginate] is true.');
         }
     }
 }

--- a/src/resources/views/components/table/index.blade.php
+++ b/src/resources/views/components/table/index.blade.php
@@ -29,7 +29,7 @@
         </div>
     @endif
     <div @class(['relative', $personalize['wrapper']])>
-        <table @class($personalize['table.base']) @if ($livewire && $loading) wire:loading.class="{{ $personalize['loading.table'] }}" @endif>
+        <table @if ($paginate) id="{{ $id }}" @endif @class($personalize['table.base']) @if ($livewire && $loading) wire:loading.class="{{ $personalize['loading.table'] }}" @endif>
             @if ($livewire && $loading)
                 <x-tallstack-ui::icon.others.loading class="{{ $personalize['loading.icon'] }}" wire:loading="{{ $target }}" />
             @endif
@@ -59,15 +59,15 @@
                 <tr @class(['bg-gray-50 dark:bg-dark-800/50' => $striped && $loop->index % 2 === 0]) @if ($livewire) wire:key="{{ md5(serialize($value).$key) }}" @endif>
                     @foreach($headers as $header)
                         @php($row = str_replace('.', '_', $header['index']))
-                        @if (isset(${$row}))
+                        @isset(${"column_".$row})
                             <td class="dark:text-dark-300 whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                                {{ ${$row}($value) }}
+                                {{ ${"column_".$row}($value) }}
                             </td>
                         @else
                             <td class="dark:text-dark-300 whitespace-nowrap px-3 py-4 text-sm text-gray-500">
                                 {{ data_get($value, $header['index']) }}
                             </td>
-                        @endif
+                        @endisset
                     @endforeach
                 </tr>
             @empty
@@ -81,6 +81,9 @@
         </table>
     </div>
     @if ($paginate && $rows->hasPages())
-        {{ $rows->onEachSide(1)->links($paginator, ['scrollTo' => true]) }}
+        {{ $rows->onEachSide(1)->links($paginator, [
+            'simplePagination' => $simplePagination,
+            'scrollTo' => '#'.$id
+        ]) }}
     @endif
 </div>

--- a/src/resources/views/components/table/paginators.blade.php
+++ b/src/resources/views/components/table/paginators.blade.php
@@ -1,4 +1,6 @@
 @php
+$simplePagination ??= false;
+
 if (! isset($scrollTo)) {
     $scrollTo = 'body';
 }
@@ -14,7 +16,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
     <div class="mt-4">
         <nav role="navigation" aria-label="Pagination Navigation">
             <!-- Mobile Buttons -->
-            <div class="flex justify-between flex-1 sm:hidden gap-x-2 mb-4">
+            <div @class(['flex flex-1 gap-x-2 mb-4', 'justify-end' => $simplePagination, 'justify-between sm:hidden' => !$simplePagination])>
                 <span>
                     @if ($paginator->onFirstPage())
                         <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-400 dark:text-dark-500 bg-gray-100 dark:bg-dark-700 border border-gray-200 dark:border-transparent cursor-default leading-5 rounded-md select-none cursor-pointer">
@@ -38,6 +40,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                     @endif
                 </span>
             </div>
+            @if (!$simplePagination)
             <!-- Desktop Buttons -->
             <div class="hidden sm:flex sm:items-center sm:justify-between">
                 <div class="mr-4">
@@ -111,6 +114,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                     </span>
                 </div>
             </div>
+            @endif
         </nav>
     </div>
 @endif

--- a/tests/Browser/Table/IndexTest.php
+++ b/tests/Browser/Table/IndexTest.php
@@ -61,9 +61,9 @@ class IndexTest extends BrowserTestCase
                         ];
                     @endphp
                     <x-table :$headers :$rows filter loading>
-                        @column('name', $row)
+                        @interact('column_name', $row)
                             {{ $row['name'] }} Test
-                        @endcolumn
+                        @endinteract
                     </x-table>
                 </div>
                 HTML;
@@ -96,9 +96,9 @@ class IndexTest extends BrowserTestCase
                         $extra = 'Extra';
                     @endphp
                     <x-table :$headers :$rows filter loading>
-                        @column('name', $row, $extra)
+                        @interact('column_name', $row, $extra)
                             {{ $row['name'] }} Test {{ $extra }}
-                        @endcolumn
+                        @endinteract
                     </x-table>
                 </div>
                 HTML;
@@ -129,9 +129,9 @@ class IndexTest extends BrowserTestCase
                         ];
                     @endphp
                     <x-table :$headers :$rows filter loading>
-                        @column('name')
+                        @interact('column_name')
                             Test
-                        @endcolumn
+                        @endinteract
                     </x-table>
                 </div>
                 HTML;
@@ -180,7 +180,7 @@ class IndexTest extends BrowserTestCase
                             ['index' => 'name', 'label' => 'Name'],
                         ];
                     @endphp
-                    <x-table :$headers :rows="$this->rows" paginate />
+                    <x-table :$headers :rows="$this->rows" paginate id="foo" />
                 </div>
                 HTML;
             }


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [x] Bug Fix
- [ ] Enhancements
- [ ] New Feature

### Description:

This pull request aims to fix an issue with the pagination element. It will now be mandatory to define a unique `id` for the table component when `paginate` is true. There was also a change in the name of the directive for column interaction, instead of `@column` it is now called `@interact`. In addition of this, the `simple-pagination` property was added to transform the paginator element in a simple style (mobile) even when in desktop devices.

### Demonstration:

The table paginated:
 
```blade
<x-table :$headers :$rows paginate id="users">
    ...
</x-table>
```

The table paginated with a simple paginator:
 
```blade
<x-table :$headers :$rows paginate id="users" simple-pagination>
    ...
</x-table>
```

The table `@interact` directive:

```blade
<x-table :$headers :$rows paginate id="users" simple-pagination>
    @interact('column_action', $row)
     ...
    @endinteract
</x-table>
```

The name of the column now must receive `column_`.