### PR TITLE
[1.x] Table Filter Block Personalization

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -96,6 +96,7 @@ class Table extends BaseComponent implements Personalization
                 'icon' => 'text-primary-500 dark:text-dark-300 absolute left-1/2 top-1/2 h-10 w-10 animate-spin',
             ],
             'empty' => 'dark:text-dark-300 col-span-full whitespace-nowrap px-3 py-4 text-sm text-gray-500',
+            'filter' => 'mb-4 flex items-end gap-x-2 sm:gap-x-0',
         ]);
     }
 

--- a/src/resources/views/components/table/index.blade.php
+++ b/src/resources/views/components/table/index.blade.php
@@ -3,7 +3,7 @@
 <div>
     @if ($livewire && $filter)
         <div @class([
-                'mb-4 flex items-end gap-x-2 sm:gap-x-0',
+                $personalize['filter'],
                 'justify-between' => $filters['quantity'] && $filters['search'],
                 'justify-end' => ! $filters['quantity'] || ! $filters['search'],
             ])>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [X] Enhancements
- [ ] New Feature

### Description:

I would like to be able to customize the styles of the block containing the table filters, above the table. Currently there's no way to set styles such as the background color of the block.

<!-- Describe your PR, which more details as possible. -->

### Demonstration:

```php
TallStackUi::personalize()
  ->block('filter')
  ->append('bg-white');
```

<!-- Insert a demonstration about the changes or the features (image or video). -->

### Related:

<!-- Link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->

### Notes:

Thanks for your consideration. This would help me by allowing me to set that style once in the app instead of wrapping each table component.

I'm not sure if the documentation auto-updates for this or not - if you need me to make a PR to that site, please let me know.

<!-- 
Insert notes here, something like an image, gif, or whatever you think is necessary.
If this PR aims to introduce new additions, like a new component, or modify the current component styles, please, add a gif or screenshots.
-->
