### PR TITLE
[1.x] Table Option - Attribute to Disable Scroll

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -32,6 +32,7 @@ class Table extends BaseComponent implements Personalization
         #[SkipDebug]
         public ?string $paginator = 'tallstack-ui::components.table.paginators',
         public ?bool $simplePagination = false,
+        public ?bool $noScroll = false,
         #[SkipDebug]
         public array|string $target = [],
     ) {

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -29,10 +29,10 @@ class Table extends BaseComponent implements Personalization
         #[SkipDebug]
         public ?array $placeholders = [],
         public ?bool $paginate = false,
+        public ?bool $persistent = false,
         #[SkipDebug]
         public ?string $paginator = 'tallstack-ui::components.table.paginators',
         public ?bool $simplePagination = false,
-        public ?bool $noScroll = false,
         #[SkipDebug]
         public array|string $target = [],
     ) {
@@ -55,8 +55,8 @@ class Table extends BaseComponent implements Personalization
         $this->filters['search'] ??= null;
 
         if ($this->id !== null) {
-            $this->id = str($this->id)->lower()
-                ->slug()
+            $this->id = str($this->id)->kebab()
+                ->lower()
                 ->value();
         }
     }
@@ -127,8 +127,8 @@ class Table extends BaseComponent implements Personalization
             throw new Exception('The table [search] message cannot be empty.');
         }
 
-        if ($this->paginate && blank($this->id)) {
-            throw new Exception('The table [id] property is required when [paginate] is true.');
+        if ($this->persistent && blank($this->id)) {
+            throw new Exception('The table [id] property is required when [persistent] is set.');
         }
     }
 }

--- a/src/resources/views/components/table/index.blade.php
+++ b/src/resources/views/components/table/index.blade.php
@@ -83,7 +83,7 @@
     @if ($paginate && $rows->hasPages())
         {{ $rows->onEachSide(1)->links($paginator, [
             'simplePagination' => $simplePagination,
-            'scrollTo' => '#'.$id
+            'scrollTo' => $noScroll ?: '#'.$id,
         ]) }}
     @endif
 </div>

--- a/src/resources/views/components/table/index.blade.php
+++ b/src/resources/views/components/table/index.blade.php
@@ -1,6 +1,6 @@
 @php($personalize = $classes())
 
-<div @if ($paginate) id="{{ $id }}" @endif>
+<div @if ($id) id="{{ $id }}" @endif>
     @if ($livewire && $filter)
         <div @class([
                 $personalize['filter'],
@@ -83,7 +83,7 @@
     @if ($paginate && $rows->hasPages())
         {{ $rows->onEachSide(1)->links($paginator, [
             'simplePagination' => $simplePagination,
-            'scrollTo' => $noScroll ?: '#'.$id,
+            'scrollTo' => $id && $persistent ? '#'.$id : false,
         ]) }}
     @endif
 </div>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

A `noScroll` option on `<x-table />` which will disable the auto-scroll to the table on pagination.

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [X] Enhancements
- [ ] New Feature

### Description:

Sometimes, the auto-scroll is undesirable, such as when a small table is in the middle of a page, and pagination makes the page jump unexpectedly. This fixes that by adding an optional `noScroll` parameter to the table tag.

<!-- Describe your PR, which more details as possible. -->

### Demonstration:

`<x-table ... no-scroll />`

<!-- Insert a demonstration about the changes or the features (image or video). -->

### Related:

<!-- Link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->

### Notes:

Thank you for your consideration of this enhancement!

<!-- 
Insert notes here, something like an image, gif, or whatever you think is necessary.
If this PR aims to introduce new additions, like a new component, or modify the current component styles, please, add a gif or screenshots.
-->
