### PR TITLE
[1.x] Allowing Definition of Inline-placeholder for `select.styled`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,8 +53,14 @@ jobs:
       - name: Pint
         run: ./vendor/bin/pint --test
 
+      - name: Clear Orchestra Testbench Cache [Before Feature]
+        run: ./vendor/bin/testbench optimize:clear
+
       - name: Feature Tests
         run: ./vendor/bin/pest --filter Feature --parallel
+
+      - name: Clear Orchestra Testbench Cache [Before Browser]
+        run: ./vendor/bin/testbench optimize:clear
 
       - name: Browser Tests
         run: ./vendor/bin/pest --filter Browser

--- a/src/View/Components/Select/Styled.php
+++ b/src/View/Components/Select/Styled.php
@@ -165,7 +165,7 @@ class Styled extends BaseComponent implements Personalization
         }
 
         if (($this->common && isset($this->options[0]) && (is_array($this->options[0]) && ! $this->select)) || ! $this->common && ! $this->select) {
-            throw new InvalidArgumentException('The [select.styled] parameter [select] must be defined');
+            throw new InvalidArgumentException('The [select.styled] parameter [select] must be defined.');
         }
 
         if ($this->common || $this->request && ! is_array($this->request)) {
@@ -173,14 +173,14 @@ class Styled extends BaseComponent implements Personalization
         }
 
         if (! isset($this->request['url'])) {
-            throw new InvalidArgumentException('The [select.styled] parameter [url] is required in the request array');
+            throw new InvalidArgumentException('The [select.styled] parameter [url] is required in the request array.');
         }
 
         $this->request['method'] ??= 'get';
         $this->request['method'] = strtolower($this->request['method']);
 
         if (! in_array($this->request['method'], ['get', 'post'])) {
-            throw new InvalidArgumentException('The [select.styled] parameter [method] must be get or post');
+            throw new InvalidArgumentException('The [select.styled] parameter [method] must be get or post.');
         }
 
         if (! isset($this->request['params'])) {
@@ -188,7 +188,7 @@ class Styled extends BaseComponent implements Personalization
         }
 
         if (! is_array($this->request['params']) || blank($this->request['params'])) {
-            throw new InvalidArgumentException('The [select.styled] parameter [params] must be an array and cannot be empty');
+            throw new InvalidArgumentException('The [select.styled] parameter [params] must be an array and cannot be empty.');
         }
     }
 }

--- a/src/View/Components/Select/Styled.php
+++ b/src/View/Components/Select/Styled.php
@@ -27,6 +27,7 @@ class Styled extends BaseComponent implements Personalization
     public function __construct(
         public ?string $label = null,
         public ?string $hint = null,
+        public ?string $placeholder = null,
         #[SkipDebug]
         public Collection|array $options = [],
         public string|array|null $request = null,
@@ -44,6 +45,7 @@ class Styled extends BaseComponent implements Personalization
         public ?bool $invalidate = null,
     ) {
         $this->placeholders = [...__('tallstack-ui::messages.select')];
+        $this->placeholder ??= $this->placeholders['default'];
 
         $this->common = ! filled($this->request);
         $this->searchable = ! $this->common ? true : $this->searchable;
@@ -146,24 +148,24 @@ class Styled extends BaseComponent implements Personalization
 
     protected function validate(): void
     {
-        if (blank($this->placeholders['default'])) {
-            throw new InvalidArgumentException('The placeholder [default] cannot be empty.');
+        if (blank($this->placeholder)) {
+            throw new InvalidArgumentException('The [select.styled] placeholder [default] cannot be empty.');
         }
 
         if (blank($this->placeholders['search'])) {
-            throw new InvalidArgumentException('The placeholder [search] cannot be empty.');
+            throw new InvalidArgumentException('The [select.styled] placeholder [search] cannot be empty.');
         }
 
         if (blank($this->placeholders['empty'])) {
-            throw new InvalidArgumentException('The placeholder [empty] cannot be empty.');
+            throw new InvalidArgumentException('The [select.styled] placeholder [empty] cannot be empty.');
         }
 
         if (filled($this->options) && filled($this->request)) {
-            throw new InvalidArgumentException('You cannot define [options] and [request] at the same time.');
+            throw new InvalidArgumentException('The [select.styled] [options] and [request] cannot be defined at the same time.');
         }
 
         if (($this->common && isset($this->options[0]) && (is_array($this->options[0]) && ! $this->select)) || ! $this->common && ! $this->select) {
-            throw new InvalidArgumentException('The [select] parameter must be defined');
+            throw new InvalidArgumentException('The [select.styled] parameter [select] must be defined');
         }
 
         if ($this->common || $this->request && ! is_array($this->request)) {
@@ -171,14 +173,14 @@ class Styled extends BaseComponent implements Personalization
         }
 
         if (! isset($this->request['url'])) {
-            throw new InvalidArgumentException('The [url] is required in the request array');
+            throw new InvalidArgumentException('The [select.styled] parameter [url] is required in the request array');
         }
 
         $this->request['method'] ??= 'get';
         $this->request['method'] = strtolower($this->request['method']);
 
         if (! in_array($this->request['method'], ['get', 'post'])) {
-            throw new InvalidArgumentException('The [method] must be get or post');
+            throw new InvalidArgumentException('The [select.styled] parameter [method] must be get or post');
         }
 
         if (! isset($this->request['params'])) {
@@ -186,7 +188,7 @@ class Styled extends BaseComponent implements Personalization
         }
 
         if (! is_array($this->request['params']) || blank($this->request['params'])) {
-            throw new InvalidArgumentException('The [params] must be an array and cannot be empty');
+            throw new InvalidArgumentException('The [select.styled] parameter [params] must be an array and cannot be empty');
         }
     }
 }

--- a/src/View/Components/Select/Styled.php
+++ b/src/View/Components/Select/Styled.php
@@ -45,7 +45,7 @@ class Styled extends BaseComponent implements Personalization
         public ?bool $invalidate = null,
     ) {
         $this->placeholders = [...__('tallstack-ui::messages.select')];
-        $this->placeholder ??= data_get($this->placeholders, 'default');
+        $this->placeholder ??= ($this->placeholders['default'] ?? null);
 
         $this->common = ! filled($this->request);
         $this->searchable = ! $this->common ? true : $this->searchable;

--- a/src/View/Components/Select/Styled.php
+++ b/src/View/Components/Select/Styled.php
@@ -45,7 +45,7 @@ class Styled extends BaseComponent implements Personalization
         public ?bool $invalidate = null,
     ) {
         $this->placeholders = [...__('tallstack-ui::messages.select')];
-        $this->placeholder ??= $this->placeholders['default'];
+        $this->placeholder ??= data_get($this->placeholders, 'default');
 
         $this->common = ! filled($this->request);
         $this->searchable = ! $this->common ? true : $this->searchable;

--- a/src/resources/views/components/select/styled.blade.php
+++ b/src/resources/views/components/select/styled.blade.php
@@ -14,7 +14,7 @@
         @js($selectable),
         @js($options),
         @js($multiple),
-        @js($placeholders['default']),
+        @js($placeholder),
         @js($searchable),
         @js($common),
         @js($livewire),

--- a/tests/Feature/Components/Select/SelectStyledTest.php
+++ b/tests/Feature/Components/Select/SelectStyledTest.php
@@ -22,7 +22,7 @@ HTML;
 
 it('can thrown exception when using options and request', function () {
     $this->expectException(ViewException::class);
-    $this->expectExceptionMessage('You cannot define [options] and [request] at the same time.');
+    $this->expectExceptionMessage('The [select.styled] [options] and [request] cannot be defined at the same time.');
 
     $component = <<<'HTML'
     <x-select.styled label="Foo bar baz" 
@@ -38,7 +38,7 @@ HTML;
 
 it('can thrown exception when select was not defined using select as common', function () {
     $this->expectException(ViewException::class);
-    $this->expectExceptionMessage('The [select] parameter must be defined');
+    $this->expectExceptionMessage('The [select.styled] parameter [select] must be defined');
 
     $component = <<<'HTML'
     <x-select.styled label="Foo bar baz" 
@@ -55,7 +55,7 @@ HTML;
 
 it('can thrown exception when request is array using unaceptable method', function (string $method) {
     $this->expectException(ViewException::class);
-    $this->expectExceptionMessage('The [method] must be get or post');
+    $this->expectExceptionMessage('The [select.styled] parameter [method] must be get or post');
 
     $component = <<<'HTML'
     <x-select.styled label="Foo bar baz" 
@@ -75,7 +75,7 @@ HTML;
 
 it('can thrown exception when params is empty', function () {
     $this->expectException(ViewException::class);
-    $this->expectExceptionMessage('The [params] must be an array and cannot be empty');
+    $this->expectExceptionMessage('The [select.styled] parameter [params] must be an array and cannot be empty.');
 
     $component = <<<'HTML'
     <x-select.styled label="Foo bar baz" 
@@ -93,7 +93,7 @@ HTML;
 
 it('can thrown exception when params is not array', function () {
     $this->expectException(ViewException::class);
-    $this->expectExceptionMessage('The [params] must be an array and cannot be empty');
+    $this->expectExceptionMessage('The [select.styled] parameter [params] must be an array and cannot be empty.');
 
     $component = <<<'HTML'
     <x-select.styled label="Foo bar baz" 
@@ -111,7 +111,7 @@ HTML;
 
 it('can thrown exception when select was not defined using select as request', function () {
     $this->expectException(ViewException::class);
-    $this->expectExceptionMessage('The [select] parameter must be defined');
+    $this->expectExceptionMessage('The [select.styled] parameter [select] must be defined.');
 
     $component = <<<'HTML'
     <x-select.styled label="Foo bar baz" 
@@ -125,7 +125,7 @@ HTML;
 
 it('can thrown exception when options is array of arrays without using select', function () {
     $this->expectException(ViewException::class);
-    $this->expectExceptionMessage('The [select] parameter must be defined');
+    $this->expectExceptionMessage('The [select.styled] parameter [select] must be defined.');
 
     $component = <<<'HTML'
     <x-select.styled label="Foo bar baz" 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [ ] Enhancements
- [x] New Feature

### Description:

This pull request aims to introduce the ability to set the placeholder of the select.styled component as inline.

### Demonstration:

```blade
<x-select.styled label="Select One Option"
                 placeholder="Custom-Inline Placeholder"
                 hint="You can choose 1, 2 or 3"
                 :options="[1,2,3]" />
```

Result:

![CleanShot 2024-01-05 at 10 07 16](https://github.com/tallstackui/tallstackui/assets/60591772/f53328ae-638e-411c-8e7e-08d2d1d0fe26)


### Related:

#218 