### PR TITLE
[1.x] Add. `header` and `footer` Slots for Table Component

### DIFF
--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\View\ComponentSlot;
 use TallStackUi\Foundation\Attributes\SkipDebug;
 use TallStackUi\Foundation\Attributes\SoftPersonalization;
 use TallStackUi\Foundation\Personalization\Contracts\Personalization;
@@ -35,6 +36,10 @@ class Table extends BaseComponent implements Personalization
         public ?bool $simplePagination = false,
         #[SkipDebug]
         public array|string $target = [],
+        #[SkipDebug]
+        public ComponentSlot|string|null $header = null,
+        #[SkipDebug]
+        public ComponentSlot|string|null $footer = null,
     ) {
         $this->placeholders = __('tallstack-ui::messages.table');
 
@@ -98,6 +103,10 @@ class Table extends BaseComponent implements Personalization
             ],
             'empty' => 'dark:text-dark-300 col-span-full whitespace-nowrap px-3 py-4 text-sm text-gray-500',
             'filter' => 'mb-4 flex items-end gap-x-2 sm:gap-x-0',
+            'slots' => [
+                'header' => 'mb-2 dark:text-dark-300 text-gray-500',
+                'footer' => 'mt-2 dark:text-dark-300 text-gray-500',
+            ],
         ]);
     }
 

--- a/src/resources/views/components/table/index.blade.php
+++ b/src/resources/views/components/table/index.blade.php
@@ -1,6 +1,11 @@
 @php($personalize = $classes())
 
 <div @if ($persistent && $id) id="{{ $id }}" @endif>
+    @if (is_string($header))
+        <p @class($personalize['slots.header'])>{{ $header }}</p>
+    @else
+        {{ $header }}
+    @endif
     @if ($livewire && $filter)
         <div @class([
                 $personalize['filter'],
@@ -89,6 +94,11 @@
             </tbody>
         </table>
     </div>
+    @if (is_string($footer))
+        <p @class($personalize['slots.footer'])>{{ $footer }}</p>
+    @else
+        {{ $footer }}
+    @endif
     @if ($paginate && (!is_array($rows) && $rows->hasPages()))
         {{ $rows->onEachSide(1)->links($paginator, [
             'simplePagination' => $simplePagination,


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [ ] Enhancements
- [x] New Feature

### Description:

This pull request aims to introduce two slots for the table component: `header` and `footer`, that can be defined as string or component slot.

### Demonstration:

```blade
{{-- Inline --}}
<x-table :$headers :$rows paginate footer="FooBar" header="BarBaz" />

{{-- Scoped --}}
<x-table :$headers :$rows paginate>
    <x-slot:header>
        Foo Bar
    </x-slot:header>
    <x-slot:footer>
        Bar Baz
    </x-slot:footer>
</x-table>
```