### PR TITLE
[1.x] Fix Icon Position of Password Component

### DIFF
--- a/src/View/Components/Form/Password.php
+++ b/src/View/Components/Form/Password.php
@@ -46,7 +46,7 @@ class Password extends BaseComponent implements Personalization
         return Arr::dot([
             'input' => [...$this->input()],
             'icon' => [
-                'wrapper' => 'absolute inset-y-0 right-0 flex items-center pr-2.5',
+                'wrapper' => 'flex items-center pr-2.5',
                 'class' => 'h-5 w-5 text-gray-400',
             ],
             'rules' => [

--- a/src/resources/views/components/form/password.blade.php
+++ b/src/resources/views/components/form/password.blade.php
@@ -12,6 +12,13 @@
             $personalize['input.color.disabled'] => $attributes->get('disabled') || $attributes->get('readonly'),
             $personalize['error'] => $error
         ]) x-on:click.outside="rules = false">
+            <input @if ($id) id="{{ $id }}" @endif
+                  {{ $attributes->class([$personalize['input.base']]) }}
+                   @if ($rules->isNotEmpty())
+                       x-on:click="rules = true"
+                       x-model.debounce="input"
+                   @endif
+                   :type="!show ? 'password' : 'text'">
             <div @class($personalize['icon.wrapper']) x-cloak>
                 @if ($generator)
                     <div class="mr-2">
@@ -27,13 +34,6 @@
                     <x-dynamic-component :component="TallStackUi::component('icon')" icon="eye-slash" :$error @class($personalize['icon.class']) x-show="show" />
                 </div>
             </div>
-            <input @if ($id) id="{{ $id }}" @endif
-                  {{ $attributes->class([$personalize['input.base']]) }}
-                   @if ($rules->isNotEmpty())
-                       x-on:click="rules = true"
-                       x-model.debounce="input"
-                   @endif
-                   :type="!show ? 'password' : 'text'">
         </div>
     </x-dynamic-component>
     @if ($rules->isNotEmpty())


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to TallStackUi.
Please, fill in the form below correctly. This will help us to understand your PR.
-->

### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [x] Enhancements
- [ ] New Feature

### Description:

This PR corrects the position of the eye and password generator icons, so that when the user uses extensions such as ''1password" and "last password", the icons are not overlapped.

### Demonstration:
![image](https://github.com/tallstackui/tallstackui/assets/12436779/3466f138-ebd3-42e9-9796-a7ee699de978)

