### PR TITLE
[1.x] Errors Component: Add slot footer

### DIFF
--- a/src/View/Components/Errors.php
+++ b/src/View/Components/Errors.php
@@ -5,6 +5,7 @@ namespace TallStackUi\View\Components;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ViewErrorBag;
+use Illuminate\View\ComponentSlot;
 use InvalidArgumentException;
 use TallStackUi\Foundation\Attributes\SoftPersonalization;
 use TallStackUi\Foundation\Personalization\Contracts\Personalization;
@@ -18,6 +19,7 @@ class Errors extends BaseComponent implements Personalization
         public ?string $icon = 'x-circle',
         public ?string $color = 'red',
         public bool $close = false,
+        public ComponentSlot|string|null $footer = null,
     ) {
         $this->title ??= __('tallstack-ui::messages.errors.title');
     }
@@ -58,6 +60,9 @@ class Errors extends BaseComponent implements Personalization
                 'list' => 'text-md list-disc space-y-1',
             ],
             'close' => 'w-5 h-5',
+            'slots' => [
+                'footer' => 'mt-2',
+            ],
         ]);
     }
 

--- a/src/resources/views/components/errors.blade.php
+++ b/src/resources/views/components/errors.blade.php
@@ -26,6 +26,11 @@
                     @endforeach
                 </ul>
             </div>
+            @if (is_string($footer))
+                <p @class($personalize['slots.footer'])>{{ $footer }}</p>
+            @else
+                {{ $footer }}
+            @endif
         </div>
     </div>
 @endif


### PR DESCRIPTION
### What:

<!-- Insert X in the square brackets to mark your PR type. -->

- [ ] Bug Fix
- [x] Enhancements
- [ ] New Feature

### Description:
This PR adds a footer slot for the errors component

### Demonstration:

![image](https://github.com/tallstackui/tallstackui/assets/12436779/726c9dc0-7dd3-45a7-8137-47760b6abd2f)
