### PR TITLE
[1.x] Fixing Button Infinity Loading Effect Out of Livewire 

### DIFF
--- a/src/resources/views/components/button/button.blade.php
+++ b/src/resources/views/components/button/button.blade.php
@@ -9,7 +9,7 @@
         $colors['background'],
         'rounded-md' => !$square && !$round,
         'rounded-full' => !$square && $round !== null,
-    ]) }} wire:loading.attr="disabled" wire:loading.class="!cursor-wait">
+    ]) }} @if ($livewire) wire:loading.attr="disabled" wire:loading.class="!cursor-wait" @endif>
     @if ($left)
         {!! $left !!}
     @elseif ($icon && $position === 'left')
@@ -21,7 +21,7 @@
     @elseif ($icon && $position === 'right')
         <x-dynamic-component :component="TallStackUi::component('icon')" :$icon @class([$personalize['icon.sizes.' . $size], $colors['icon']]) />
     @endif
-    @if ($loading)
+    @if ($livewire && $loading)
         <x-tallstack-ui::icon.others.loading-button :$loading :$delay @class([
             'animate-spin',
             $personalize['icon.sizes.' . $size],

--- a/src/resources/views/components/button/circle.blade.php
+++ b/src/resources/views/components/button/circle.blade.php
@@ -9,7 +9,7 @@
             $personalize['wrapper.base'],
             $personalize['wrapper.sizes.' . $size],
             $colors['background']
-        ]) }} wire:loading.attr="disabled" wire:loading.class="!cursor-wait">
+        ]) }} @if ($livewire) wire:loading.attr="disabled" wire:loading.class="!cursor-wait" @endif>
 @if ($icon)
     @if ($loading)
         @if ($delay === 'longest')
@@ -31,9 +31,9 @@
         <x-dynamic-component :component="TallStackUi::component('icon')" :$icon @class([$personalize['icon.sizes.' . $size], $colors['icon']]) />
     @endif
 @else
-    <span @if ($loading) wire:loading.remove @endif @class([$personalize['text.sizes.' . $size]])>{{ $text ?? $slot }}</span>
+    <span @if ($livewire && $loading) wire:loading.remove @endif @class([$personalize['text.sizes.' . $size]])>{{ $text ?? $slot }}</span>
 @endif
-@if ($loading)
+@if ($livewire && $loading)
     <x-tallstack-ui::icon.others.loading-button :$loading :$delay @class([
         'animate-spin',
         $personalize['icon.sizes.' . $size],


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

This pull request is related to #284, which aims to not show the spinner loading effect for buttons that are not used within Livewire components or when `@livewireStyles` has not been configured on the page. Therefore, loading will only be applied when the button is inside Livewire components.