### PR TITLE
[1.x] Fixing Input Focus

### DIFF
--- a/src/View/Components/Form/Traits/DefaultInputClasses.php
+++ b/src/View/Components/Form/Traits/DefaultInputClasses.php
@@ -21,7 +21,7 @@ trait DefaultInputClasses
     {
         return [
             'wrapper' => 'focus:ring-primary-600 focus-within:focus:ring-primary-600 focus-within:ring-primary-600 dark:focus-within:ring-primary-600 flex rounded-md px-2 ring-1 transition focus-within:ring-2',
-            'base' => 'w-full border-0 bg-transparent p-1 py-1.5 ring-0 ring-inset focus:ring-transparent sm:text-sm sm:leading-6',
+            'base' => 'w-full border-0 bg-transparent p-1 py-1.5 ring-0 ring-inset focus:outline-none focus:ring-transparent sm:text-sm sm:leading-6',
             'slot' => 'dark:text-dark-400 m-1 flex select-none items-center whitespace-nowrap text-gray-500 transition sm:text-sm',
             'color' => [
                 'base' => 'dark:ring-dark-600 dark:text-dark-300 dark:placeholder-dark-500 text-gray-600 ring-gray-300 placeholder:text-gray-400',

--- a/src/resources/views/components/form/input.blade.php
+++ b/src/resources/views/components/form/input.blade.php
@@ -28,7 +28,7 @@
         @if ($prefix)
             <span @class([$personalize['input.class.slot'], $personalize['error'] => $error])>{{ $prefix }}</span>
         @endif
-        <input @if ($id) id="{{ $id }}" @endif {{ $attributes->class($personalize['input.class.base']) }}>
+        <input @if ($id) id="{{ $id }}" @endif type="{{ $attributes->get('type', 'text') }}" {{ $attributes->class($personalize['input.class.base']) }}>
         @if ($suffix)
             <span @class([$personalize['input.class.slot'], $personalize['error'] => $error])>{{ $suffix }}</span>
         @endif


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

1. Introducing `focus:outline-none` to fix issues when focusing on input.
2. Input defaults to `text` when the type is not defined.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
