### PR TITLE
[1.x] Fixing `Tab` Components With Livewire Components

### DIFF
--- a/src/resources/views/components/tab/tab.blade.php
+++ b/src/resources/views/components/tab/tab.blade.php
@@ -4,7 +4,7 @@
 @endphp
 
 <div @if (!$selected) x-data="tallstackui_tab({!! $entangle !!})" @else x-data="tallstackui_tab(@js($selected))"@endif
-    @class($personalize['wrapper'])>
+    @class($personalize['wrapper']) wire:ignore>
     <div class="p-2 sm:p-0">
         <select id="tab-select-{{ $id }}"
                 x-model="tab"


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

Allowing the usage of Livewire components inside the tab items by adding the `wire:ignore`