### PR TITLE
[1.x] Fixing `intl` Exception in Upload Component

### DIFF
--- a/src/resources/views/components/form/upload.blade.php
+++ b/src/resources/views/components/form/upload.blade.php
@@ -132,7 +132,7 @@
                                         <p @class($personalize['item.title'])>{{ $file['real_name'] }}</p>
                                         <x-dynamic-component :component="TallStackUi::component('error')"
                                                              :property="is_array($value) ? $property . '.' . $key : $property" />
-                                        @if (class_exists(\Illuminate\Support\Number::class))
+                                        @if (extension_loaded('intl') && class_exists(\Illuminate\Support\Number::class))
                                             <p @class($personalize['item.size'])>
                                                 <span>{{ __('tallstack-ui::messages.upload.size') }}: </span>
                                                 <span>{{ $file['size'] }}</span>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

This pull request adds verification of `intl` PHP extension loaded to prevent exceptions due to the fact the `Number` class of Laravel uses this for the `format` method. Without the `intl` extension, the `Size` of files in the upload component will not be displayed.
