### PR TITLE
[1.x] Prevents Usage of `Upload` Components Without `wire:model`

### DIFF
--- a/src/resources/views/components/form/upload.blade.php
+++ b/src/resources/views/components/form/upload.blade.php
@@ -1,9 +1,10 @@
 @php
     \TallStackUi\Foundation\Exceptions\MissingLivewireException::throwIf($livewire, 'upload');
-    if ($delete && !method_exists($this, $deleteMethod)) throw new Exception('The [upload] component delete method [' . $deleteMethod . '] does not exist in [' . get_class($this) . '].');
     $property = $bind($attributes, null, $livewire)[0];
     $personalize = $classes();
     $value = data_get($this, $property);
+    if (is_null($property)) throw new Exception('The [upload] component requires a property to bind using [wire:model].');
+    if ($delete && !method_exists($this, $deleteMethod)) throw new Exception('The [upload] component delete method [' . $deleteMethod . '] does not exist in [' . get_class($this) . '].');
 @endphp
 
 <div x-data="tallstackui_formUpload(

--- a/tests/Browser/Form/UploadTest.php
+++ b/tests/Browser/Form/UploadTest.php
@@ -416,6 +416,22 @@ class UploadTest extends BrowserTestCase
     }
 
     /** @test */
+    public function can_thrown_exception_if_property_bind_was_not_defined()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-upload label="Document" />
+                </div>
+                HTML;
+            }
+        })->assertSee('The [upload] component requires a property to bind using [wire:model].');
+    }
+
+    /** @test */
     public function can_upload_multiple_file(): void
     {
         Livewire::visit(new class extends Component


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

This pull request aims to prevent the usage of `upload` component without the definition of the `wire:model` to bind the Livewire property that will receive the upload. An exception will be thrown when the `wire:model` is not set.