### PR TITLE
[1.x][Summer Release] Introducing Command to Easily Set Component Prefixes

### DIFF
--- a/src/Foundation/Console/SetupPrefixCommand.php
+++ b/src/Foundation/Console/SetupPrefixCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace TallStackUi\Foundation\Console;
+
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
+
+use function Laravel\Prompts\text;
+
+class SetupPrefixCommand extends Command
+{
+    public $description = 'TallStackUI prefix set up';
+
+    public $signature = 'tallstackui:setup-prefix';
+
+    public function handle(): int
+    {
+        if (! file_exists(config_path('tallstackui.php'))) {
+            Process::run('php artisan vendor:publish --tag=tallstackui.config');
+        }
+
+        $prefix = text('What prefix do you want to use for the TallStackUI components?', required: true);
+        $result = $this->setup($prefix);
+
+        if ($result !== true) {
+            $this->components->error($result);
+
+            return self::FAILURE;
+        }
+
+        Process::run('php artisan view:clear');
+
+        $this->components->info('The prefix ['.$prefix.'] was successfully set up.');
+
+        return self::SUCCESS;
+    }
+
+    private function setup(string $prefix): bool|string
+    {
+        try {
+            $prefix = $prefix === 'null' ? var_export(null, true) : "'$prefix'";
+
+            $config = file_get_contents(config_path('tallstackui.php'));
+            $update = preg_replace("/('prefix' => )[^,]+/", "\$1$prefix", $config);
+            file_put_contents(config_path('tallstackui.php'), $update);
+
+            return true;
+        } catch (Exception $e) {
+            return $e->getMessage();
+        }
+    }
+}

--- a/src/Foundation/Support/Blade/BladeComponentPrefix.php
+++ b/src/Foundation/Support/Blade/BladeComponentPrefix.php
@@ -11,7 +11,7 @@ class BladeComponentPrefix
 
     public function __invoke(string $component): string
     {
-        if (blank($this->prefix)) {
+        if (blank($this->prefix) || $this->prefix === false) {
             return $component;
         }
 

--- a/src/TallStackUiServiceProvider.php
+++ b/src/TallStackUiServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use TallStackUi\Facades\TallStackUi as Facade;
 use TallStackUi\Foundation\Console\SetupIconsCommand;
+use TallStackUi\Foundation\Console\SetupPrefixCommand;
 use TallStackUi\Foundation\Personalization\Personalization;
 use TallStackUi\Foundation\Personalization\PersonalizationResources;
 use TallStackUi\Foundation\Support\Blade\BladeComponentPrefix;
@@ -40,7 +41,7 @@ class TallStackUiServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->commands(SetupIconsCommand::class);
+        $this->commands([SetupIconsCommand::class, SetupPrefixCommand::class]);
     }
 
     protected function registerComponentPersonalizations(): void


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

This pull request aims to introduce a command to easily set up component prefixes by using:

```shell
php artisan tallstackui:setup-prefix
```

### Demonstration & Notes:

![CleanShot 2024-02-20 at 13 57 29](https://github.com/tallstackui/tallstackui/assets/60591772/1eff712a-dbe2-4a4e-bf8e-74a533ce3e94)
