### PR TITLE
[1.x] Fix Tag Input and Number Hold on Mobile Devices

### DIFF
--- a/src/resources/views/components/form/number.blade.php
+++ b/src/resources/views/components/form/number.blade.php
@@ -30,10 +30,10 @@
                x-ref="input">
             <button x-on:click="decrement()"
                     x-on:mousedown="interval = setInterval(() => decrement(), delay * 100);"
-                    x-on:touchstart="interval = setInterval(() => decrement(), delay * 100);"
-                    x-on:mouseup="clearInterval(interval);"
-                    x-on:mouseleave="clearInterval(interval);"
-                    x-on:touchend="clearInterval(interval);"
+                    x-on:touchstart="if (!interval) interval = setInterval(() => decrement(), delay * 100);"
+                    x-on:touchend="if (interval) { clearInterval(interval); interval = null; }"
+                    x-on:mouseup="if (interval) { clearInterval(interval); interval = null; }"
+                    x-on:mouseleave="if (interval) { clearInterval(interval); interval = null; }"
                     x-ref="minus"
                     type="button"
                     @if ($attributes->get('disabled') || $attributes->get('readonly')) disabled @endif
@@ -45,10 +45,10 @@
             </button>
             <button x-on:click="increment()"
                     x-on:mousedown="interval = setInterval(() => increment(), delay * 100);"
-                    x-on:touchstart="interval = setInterval(() => increment(), delay * 100);"
-                    x-on:mouseup="clearInterval(interval);"
-                    x-on:mouseleave="clearInterval(interval);"
-                    x-on:touchend="clearInterval(interval);"
+                    x-on:touchstart="if (!interval) interval = setInterval(() => increment(), delay * 100);"
+                    x-on:touchend="if (interval) { clearInterval(interval); interval = null; }"
+                    x-on:mouseup="if (interval) { clearInterval(interval); interval = null; }"
+                    x-on:mouseleave="if (interval) { clearInterval(interval); interval = null; }"
                     x-ref="plus"
                     type="button"
                     @if ($attributes->get('disabled') || $attributes->get('readonly')) disabled @endif

--- a/src/resources/views/components/form/tag.blade.php
+++ b/src/resources/views/components/form/tag.blade.php
@@ -37,6 +37,7 @@
                         // conflicts when component is used in non-livewire mode
                         ->except(['value', 'name'])
                         ->class([
+                            'w-4',
                             $personalize['input.class.base'],
                             $personalize['input.class.color.base'] => !$error,
                             $personalize['input.class.color.background'],


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

This PR fixes a problem with the tag on mobile where when inserting an item, the cursor goes down expanding the input without need

It also fixes a problem in the number component on mobile devices, where when clicking and holding to increment or decrement it is constantly active and it is not possible to stop.
