### PR TITLE
[1.x] Setup Prefix Using Env

### DIFF
--- a/src/View/Components/Select/Styled.php
+++ b/src/View/Components/Select/Styled.php
@@ -102,7 +102,7 @@ class Styled extends BaseComponent implements Personalization
             ],
             'itens' => [
                 'wrapper' => 'truncate',
-                'placeholder' => 'dark:text-dark-400 leading-6 text-gray-400',
+                'placeholder' => 'dark:text-dark-400 truncate leading-6 text-gray-400',
                 'single' => 'dark:text-dark-300 leading-6 text-gray-600',
                 'multiple' => [
                     'item' => 'dark:text-dark-100 dark:bg-dark-700 dark:ring-dark-600 inline-flex h-6 items-center space-x-1 rounded-lg bg-gray-100 px-2 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-200',

--- a/src/config.php
+++ b/src/config.php
@@ -14,7 +14,7 @@ return [
     |
     | For example: prefixing as 'ts-', the `alert` usage will be: '<x-ts-alert />'
     */
-    'prefix' => null,
+    'prefix' => env('TALLSTACKUI_PREFIX'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

This PR adds the possibility of defining the component prefix through the env file, related to #351 
