### PR TITLE
[1.x] Slide Fix Close

### DIFF
--- a/src/resources/views/components/slide.blade.php
+++ b/src/resources/views/components/slide.blade.php
@@ -44,7 +44,7 @@
                      x-transition:leave-start="@if ($configurations['left']) -translate-x-0 @else translate-x-0 @endif"
                      x-transition:leave-end="@if ($configurations['left']) -translate-x-full @else translate-x-full @endif"
                      @class(['pointer-events-auto w-screen', $configurations['size']])
-                     @if (!$configurations['persistent']) x-on:click.outside="show = false" @endif>
+                     @if (!$configurations['persistent']) x-on:mousedown.away="show = false" @endif>
                     <div @class($personalize['wrapper.fifth'])>
                         <div @class($personalize['header'])>
                             <div @class(['flex items-start', 'justify-between' => $title !== null, 'justify-end' => $title === null])>

--- a/tests/Browser/Slide/IndexTest.php
+++ b/tests/Browser/Slide/IndexTest.php
@@ -38,7 +38,7 @@ class IndexTest extends BrowserTestCase
             ->waitForText('Foo bar')
             ->assertSee('Foo bar')
             ->assertSeeIn('@target', 'Opened')
-            ->clickAtPoint(350, 350)
+            ->clickAtXPath('/html/body/div[3]/div/div[2]/div')
             ->waitUntilMissingText('Foo bar')
             ->assertDontSee('Foo bar')
             ->assertSeeIn('@target', 'Closed');


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

This PR fixes an issue with the slide component that when clicked inside and dragged the course out, it would close. Now it keeps it open and only closes if you click on the backdrop.