### PR TITLE
[1.x] Add `block` class to `form.error` component

### DIFF
--- a/src/View/Components/Form/Error.php
+++ b/src/View/Components/Form/Error.php
@@ -22,6 +22,6 @@ class Error extends BaseComponent implements Personalization
 
     public function personalization(): array
     {
-        return ['text' => 'mt-2 text-sm font-medium text-red-500'];
+        return ['text' => 'block mt-2 text-sm font-medium text-red-500'];
     }
 }

--- a/src/View/Components/Form/Error.php
+++ b/src/View/Components/Form/Error.php
@@ -22,6 +22,6 @@ class Error extends BaseComponent implements Personalization
 
     public function personalization(): array
     {
-        return ['text' => 'block mt-2 text-sm font-medium text-red-500'];
+        return ['text' => 'mt-2 block text-sm font-medium text-red-500'];
     }
 }

--- a/src/View/Components/Form/Hint.php
+++ b/src/View/Components/Form/Hint.php
@@ -22,6 +22,6 @@ class Hint extends BaseComponent implements Personalization
 
     public function personalization(): array
     {
-        return ['text' => 'mt-2 text-sm text-gray-500 dark:text-dark-400'];
+        return ['text' => 'dark:text-dark-400 mt-2 block text-sm text-gray-500'];
     }
 }


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

The `form.input` component uses a `form.error` component.
Inside this component, there is a `mt-2` class, but it is not rendered because the default display for a `span` element is `inline`, so all padding and margins are not applied to the element. 
To make the `mt-2` applied correctly, we need to insert the `block` class into the `span` element.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->

**Default**
![error-without-block](https://github.com/tallstackui/tallstackui/assets/14243337/ddc20f2c-3688-4dc8-bbf0-1bfd7acc5e93)

**With `block`**
![error-with-block](https://github.com/tallstackui/tallstackui/assets/14243337/4cf909b6-441f-4296-97ea-4c9f90166053)


