### PR TITLE
[1.x] Add Support to HTML in Interactions (Dialog, Toast & Banner Wireable)

### DIFF
--- a/src/Actions/Banner.php
+++ b/src/Actions/Banner.php
@@ -35,7 +35,6 @@ class Banner extends AbstractInteraction
         $this->data = [
             'type' => 'error',
             'title' => $title,
-            'description' => $description,
         ];
 
         return $this;
@@ -46,7 +45,6 @@ class Banner extends AbstractInteraction
         $this->data = [
             'type' => 'info',
             'title' => $title,
-            'description' => $description,
         ];
 
         return $this;
@@ -70,7 +68,6 @@ class Banner extends AbstractInteraction
         $this->data = [
             'type' => 'success',
             'title' => $title,
-            'description' => $description,
         ];
 
         return $this;
@@ -81,7 +78,6 @@ class Banner extends AbstractInteraction
         $this->data = [
             'type' => 'warning',
             'title' => $title,
-            'description' => $description,
         ];
 
         return $this;

--- a/src/resources/views/components/banner.blade.php
+++ b/src/resources/views/components/banner.blade.php
@@ -68,7 +68,7 @@
                                          outline
                                          @class([$personalize['icon']]) />
                 </div>
-                <span class="text-white" x-text="text"></span>
+                <span class="text-white" x-html="text"></span>
             </div>
         @else
             <span @class([$personalize['text'], $colors['text'] ?? $color['text']])>

--- a/src/resources/views/components/interaction/dialog.blade.php
+++ b/src/resources/views/components/interaction/dialog.blade.php
@@ -78,9 +78,9 @@
                         </div>
                     </div>
                     <div @class($personalize['text.wrapper'])>
-                        <h3 @class($personalize['text.title']) x-text="dialog.title"></h3>
+                        <h3 @class($personalize['text.title']) x-html="dialog.title"></h3>
                         <div class="mt-2">
-                            <p @class($personalize['text.content']) x-text="dialog.description"></p>
+                            <p @class($personalize['text.content']) x-html="dialog.description"></p>
                         </div>
                     </div>
                 </div>

--- a/src/resources/views/components/interaction/toast.blade.php
+++ b/src/resources/views/components/interaction/toast.blade.php
@@ -61,9 +61,9 @@
                     </div>
                     <div @class($personalize['content.wrapper'])>
                         <p @class($personalize['content.text']) x-bind:class="{ 'font-medium' : !toast.confirm, 'font-semibold' : toast.confirm }"
-                           x-text="toast.title"></p>
+                           x-html="toast.title"></p>
                         <p @class($personalize['content.description'])
-                           x-text="toast.description"
+                           x-html="toast.description"
                            x-show="!toast.expandable"
                            x-bind:class="{ 'truncate': toast.expandable }"
                            x-collapse.min.20px></p>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

Relates to #421. This PR aims to add support to HTML into Interactions (Dialog, Toast && Banner Wireable), by changing from `x-text` to `x-html` Alpine directives.

### Demonstration & Notes:

The code:
```php
$this->dialog()
    ->success('Success!', '<b class="underline">Now</b> you can use<br><i>HTML</i> in <b>Dialogs</b>')
    ->send();
```

The output:
![CleanShot 2024-04-14 at 00 53 39](https://github.com/tallstackui/tallstackui/assets/60591772/8e773abb-8d11-429b-96b2-dec6496fbaee)
