### PR TITLE
[1.x] Add Support for Env Variables for Icon Setup

### DIFF
--- a/src/Foundation/Console/SetupIconsCommand.php
+++ b/src/Foundation/Console/SetupIconsCommand.php
@@ -74,21 +74,13 @@ class SetupIconsCommand extends Command
         $zip->extractTo($extract);
         $zip->close();
 
-        $this->flush($file, $extract);
+        $this->prepare($file, $extract);
 
         return true;
     }
 
-    private function flush(string $file, string $extract): void
+    private function flush(): void
     {
-        if ($this->option('force')) {
-            File::deleteDirectory(self::PATH.$this->data->get('type'));
-        }
-
-        File::copyDirectory($extract, self::PATH.$this->data->get('type'));
-        File::deleteDirectory($extract);
-        unlink($file);
-
         if (config('tallstackui.icons.flush', true) === false) {
             return;
         }
@@ -103,6 +95,19 @@ class SetupIconsCommand extends Command
             // avoid the existence of unused files.
             File::deleteDirectory(self::PATH.$type);
         }
+    }
+
+    private function prepare(string $file, string $extract): void
+    {
+        if ($this->option('force')) {
+            File::deleteDirectory(self::PATH.$this->data->get('type'));
+        }
+
+        File::copyDirectory($extract, self::PATH.$this->data->get('type'));
+        File::deleteDirectory($extract);
+        unlink($file);
+
+        $this->flush();
     }
 
     private function setup(): bool|string
@@ -132,6 +137,8 @@ class SetupIconsCommand extends Command
         }
 
         if (! $this->option('force') && is_dir(self::PATH.$type)) {
+            $this->flush();
+
             return 'The icons selected ['.$type.'] are already installed.';
         }
 

--- a/src/config.php
+++ b/src/config.php
@@ -60,7 +60,7 @@ return [
         |----------------------------------
         | Allowed: heroicons, phosphoricons, google, tablericons.
         */
-        'type' => 'heroicons',
+        'type' => env('TALLSTACKUI_ICON_TYPE', 'heroicons'),
 
         /*
         |----------------------------------
@@ -73,7 +73,7 @@ return [
         | Google: default
         | Tablericons: default
         */
-        'style' => 'solid',
+        'style' => env('TALLSTACKUI_ICON_STYLE', 'solid'),
 
         /*
         |----------------------------------


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

This PR aims to add the possibility of using the env variables to set the icon setup: 
`TALLSTACKUI_ICON_TYPE` & `TALLSTACKUI_ICON_STYLE`

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
