### PR TITLE
[1.x] Introducing Ability to Use Rating Component as Static

### DIFF
--- a/src/Foundation/Exceptions/MissingLivewireException.php
+++ b/src/Foundation/Exceptions/MissingLivewireException.php
@@ -12,9 +12,19 @@ class MissingLivewireException extends Exception
     }
 
     /** @throws MissingLivewireException */
-    public static function throwIf(bool $livewire, string $component): ?self
+    public static function throwIf(bool $boolean, string $component): ?self
     {
-        if ($livewire) {
+        if ($boolean) {
+            return null;
+        }
+
+        throw new self($component);
+    }
+
+    /** @throws MissingLivewireException */
+    public static function throwUnless(bool $boolean, string $component): ?self
+    {
+        if (! $boolean) {
             return null;
         }
 

--- a/src/View/Components/Rating.php
+++ b/src/View/Components/Rating.php
@@ -21,6 +21,7 @@ class Rating extends BaseComponent implements Personalization
         public ?bool $sm = null,
         public ?bool $md = null,
         public ?bool $lg = null,
+        public ?bool $static = false,
         public ?string $color = 'primary',
         #[SkipDebug]
         public ?string $size = null,

--- a/src/resources/views/components/form/upload.blade.php
+++ b/src/resources/views/components/form/upload.blade.php
@@ -4,7 +4,6 @@
     $personalize = $classes();
     $value = data_get($this, $property);
     if (is_null($property)) throw new Exception('The [upload] component requires a property to bind using [wire:model].');
-    if ($delete && !method_exists($this, $deleteMethod)) throw new Exception('The [upload] component delete method [' . $deleteMethod . '] does not exist in [' . get_class($this) . '].');
 @endphp
 
 <div x-data="tallstackui_formUpload(

--- a/src/resources/views/components/form/upload.blade.php
+++ b/src/resources/views/components/form/upload.blade.php
@@ -1,6 +1,6 @@
 @php
     \TallStackUi\Foundation\Exceptions\MissingLivewireException::throwIf($livewire, 'upload');
-    $property = $bind($attributes, null, $livewire)[0];
+    [$property] = $bind($attributes, livewire: $livewire);
     $personalize = $classes();
     $value = data_get($this, $property);
     if (is_null($property)) throw new Exception('The [upload] component requires a property to bind using [wire:model].');

--- a/src/resources/views/components/rating.blade.php
+++ b/src/resources/views/components/rating.blade.php
@@ -1,7 +1,7 @@
 @php
-    \TallStackUi\Foundation\Exceptions\MissingLivewireException::throwIf($livewire, 'reaction');
+    if (!$static) \TallStackUi\Foundation\Exceptions\MissingLivewireException::throwIf($livewire, 'reaction');
     $personalize = $classes();
-    $property = $bind($attributes, livewire: $livewire)[0];
+    [$property] = $bind($attributes, livewire: $livewire);
     $rate ??= data_get($this, $property);
 @endphp
 

--- a/src/resources/views/components/rating.blade.php
+++ b/src/resources/views/components/rating.blade.php
@@ -22,7 +22,7 @@
         @endif
     @endif
     <template x-for="(star, index) in Array.from({ length: quantity })" :key="index">
-        <button x-on:click.prevent="evaluate('{{ $evaluateMethod }}', index + 1);"
+        <button @if (!$static) x-on:click.prevent="evaluate('{{ $evaluateMethod }}', index + 1);" @endif
                 {{ $attributes->only('x-on:evaluate') }}
                 @class($personalize['button'])>
                 <svg xmlns="http://www.w3.org/2000/svg"

--- a/src/resources/views/components/rating.blade.php
+++ b/src/resources/views/components/rating.blade.php
@@ -2,7 +2,7 @@
     if (!$static) \TallStackUi\Foundation\Exceptions\MissingLivewireException::throwIf($livewire, 'reaction');
     $personalize = $classes();
     [$property] = $bind($attributes, livewire: $livewire);
-    $rate ??= data_get($this, $property);
+    $rate ??= $livewire ? data_get($this, $property) : $rate;
 @endphp
 
 <div @class($personalize['wrapper'])

--- a/src/resources/views/components/reaction.blade.php
+++ b/src/resources/views/components/reaction.blade.php
@@ -1,6 +1,6 @@
 @php
     \TallStackUi\Foundation\Exceptions\MissingLivewireException::throwIf($livewire, 'reaction');
-    $entangle = $bind($attributes, null, $livewire)[3];
+    $entangle = $bind($attributes, livewire: $livewire)[3];
     $personalize = $classes();
     $extension = $animated === true ? 'gif' : 'png';
     $id = $this->getId();

--- a/tests/Browser/Form/UploadTest.php
+++ b/tests/Browser/Form/UploadTest.php
@@ -395,30 +395,6 @@ class UploadTest extends BrowserTestCase
     }
 
     /** @test */
-    public function can_thrown_exception_if_delete_method_does_not_exists()
-    {
-        Livewire::visit(new class extends Component
-        {
-            use WithFileUploads;
-
-            public $photo;
-
-            public function render(): string
-            {
-                return <<<'HTML'
-                <div>
-                    @if ($photo)
-                        <p dusk="uploaded">{{ $photo->getClientOriginalName() }}</p>
-                    @endif
-                    
-                    <x-upload label="Document" wire:model.live="photo" delete />
-                </div>
-                HTML;
-            }
-        })->assertSee('The [upload] component delete method');
-    }
-
-    /** @test */
     public function can_thrown_exception_if_property_bind_was_not_defined()
     {
         Livewire::visit(new class extends Component

--- a/tests/Browser/Rating/IndexTest.php
+++ b/tests/Browser/Rating/IndexTest.php
@@ -145,7 +145,7 @@ class IndexTest extends BrowserTestCase
                 <div>
                     <p dusk="rating">{{ $rating }}</p>
 
-                    <x-rating />
+                    <x-rating static />
                 </div>
                 HTML;
             }

--- a/tests/Browser/Rating/IndexTest.php
+++ b/tests/Browser/Rating/IndexTest.php
@@ -131,4 +131,34 @@ class IndexTest extends BrowserTestCase
             ->assertVisible('@rated')
             ->assertSeeIn('@rated', 'rated');
     }
+
+    /** @test */
+    public function cannot_rating_when_static(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public string $rating = '3.5';
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <p dusk="rating">{{ $rating }}</p>
+
+                    <x-rating />
+                </div>
+                HTML;
+            }
+
+            public function evaluate(string $rating): void
+            {
+                $this->rating = $rating;
+            }
+        })
+            ->assertSeeIn('@rating', '3.5')
+            ->clickAtXPath('/html/body/div[3]/div/button[4]')
+            ->waitForTextIn('@rating', '3.5')
+            ->assertSeeIn('@rating', '3.5')
+            ->assertSee('3.5');
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

This PR aims to introduce the boolean `$static` in the classification component that allows the component to be used as static, without the need to react to clicks.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
