### PR TITLE
[1.x] Fixing Tab Component with Accents

### DIFF
--- a/src/resources/views/components/tab/items.blade.php
+++ b/src/resources/views/components/tab/items.blade.php
@@ -3,6 +3,6 @@
     $left = is_string($left) ? $left : ($left?->toHtml() ?? null);
 @endphp
 
-<div x-show="selected === '{{ $tab }}'" role="tabpanel" x-init="tabs.push({ tab: '{{ $tab }}', right: @js($right), left: @js($left) });">
+<div x-show="selected === @js($tab)" role="tabpanel" x-init="tabs.push({ tab: @js($tab), right: @js($right), left: @js($left) });">
     {{ $slot }}
 </div>

--- a/tests/Browser/Tab/IndexTest.php
+++ b/tests/Browser/Tab/IndexTest.php
@@ -9,6 +9,37 @@ use Tests\Browser\BrowserTestCase;
 class IndexTest extends BrowserTestCase
 {
     /** @test */
+    public function can_render_and_select_with_accents(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>        
+                    <x-tab selected="Données d'identification">
+                        <x-tab.items tab="Données d'identification">
+                            Lorem ipsum dolor sit amet
+                        </x-tab.items>
+                        <x-tab.items tab="Données d'accès incorrectes">
+                            Consectetur adipiscing elit
+                        </x-tab.items>
+                    </x-tab>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSee('Données d\'identification')
+            ->assertSee('Lorem ipsum dolor sit amet')
+            ->assertSee('Données d\'accès incorrectes')
+            ->assertDontSee('Consectetur adipiscing elit')
+            ->clickAtXPath('/html/body/div[3]/div/ul/li[2]')
+            ->waitForText('Consectetur adipiscing elit')
+            ->assertSee('Consectetur adipiscing elit')
+            ->assertDontSee('Lorem ipsum dolor sit amet');
+    }
+
+    /** @test */
     public function can_render_left_slot_using_slot(): void
     {
         Livewire::visit(new class extends Component


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

This PR aims to fix an issue in tab components when using accents in items and selected tabs: 

```blade
<x-tab selected="Données d'identification">
    <x-tab.items tab="Données d'identification">
        Tab 1
    </x-tab.items>
    <x-tab.items tab="Tab 2">
        Tab 2
    </x-tab.items>
    <x-tab.items tab="Tab 3">
        Tab 3
    </x-tab.items>
</x-tab>
```

Relates to #453 

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
