### PR TITLE
[1.x] Tab Change Color Divider on Dark Mode

### DIFF
--- a/src/View/Components/Tab/Tab.php
+++ b/src/View/Components/Tab/Tab.php
@@ -29,8 +29,8 @@ class Tab extends BaseComponent implements Personalization
                 'padding' => 'p-2 sm:p-0',
                 'body' => 'soft-scrollbar hidden flex-nowrap overflow-auto sm:flex',
                 'content' => 'text-secondary-700 dark:text-dark-300 p-4',
-                'divider' => 'hidden h-px border-0 bg-gray-300 dark:bg-gray-600 sm:block',
-                'select' => 'focus:border-primary-500 focus:ring-primary-500 dark:bg-dark-700 dark:border-dark-500 w-full rounded-lg border-gray-200 px-4 py-3 dark:text-gray-400 sm:hidden',
+                'divider' => 'hidden h-px border-0 bg-gray-300 dark:bg-dark-600 sm:block',
+                'select' => 'focus:border-primary-500 focus:ring-primary-500 dark:bg-dark-700 dark:border-dark-500 w-full rounded-lg border-gray-200 px-4 py-3 dark:text-dark-400 sm:hidden',
             ],
             'item' => [
                 'wrapper' => 'inline-flex items-center gap-2 whitespace-nowrap p-4 transition-all',


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

This PR changes tab divider colors to properly suit darkmode
