### PR TITLE
[1.x] Add `type="button"` as Default

### DIFF
--- a/src/resources/views/components/button/button.blade.php
+++ b/src/resources/views/components/button/button.blade.php
@@ -3,13 +3,13 @@
     $personalize = $classes();
 @endphp
 
-<{{ $tag }} @if ($href) href="{{ $href }}" @else role="button" @endif {{ $attributes->class([
+<{{ $tag }} @if ($href) href="{{ $href }}" @else role="button" @endif {{ $attributes->except('type')->class([
         $personalize['wrapper.class'],
         $personalize['wrapper.sizes.' . $size],
         $colors['background'],
         'rounded-md' => !$square && !$round,
         'rounded-full' => !$square && $round !== null,
-    ]) }} @if ($livewire && $loading) wire:loading.attr="disabled" wire:loading.class="!cursor-wait" @endif>
+    ]) }} type="{{ $attributes->get('type', 'button') }}" @if ($livewire && $loading) wire:loading.attr="disabled" wire:loading.class="!cursor-wait" @endif>
     @if ($left)
         {!! $left !!}
     @elseif ($icon && $position === 'left')

--- a/src/resources/views/components/button/circle.blade.php
+++ b/src/resources/views/components/button/circle.blade.php
@@ -3,11 +3,11 @@
     $personalize = $classes();
 @endphp
 
-<{{ $tag }} @if ($href) href="{{ $href }}" @else role="button" @endif {{ $attributes->class([
+<{{ $tag }} @if ($href) href="{{ $href }}" @else role="button" @endif {{ $attributes->except('type')->class([
         $personalize['wrapper.base'],
         $personalize['wrapper.sizes.' . $size],
         $colors['background']
-    ]) }} @if ($livewire && $loading) wire:loading.attr="disabled" wire:loading.class="!cursor-wait" @endif>
+    ]) }} type="{{ $attributes->get('type', 'button') }}" @if ($livewire && $loading) wire:loading.attr="disabled" wire:loading.class="!cursor-wait" @endif>
 @if ($icon)
     <x-dynamic-component :component="TallStackUi::component('icon')"
                          :$icon


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

Relates to #495. This PR aims to add the `type="button"` as default in the buttons when `type` was not set.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
