### PR TITLE
[1.x] Adapting Scoped Personalization to Support Personalization Using Class

### DIFF
--- a/src/View/Components/BaseComponent.php
+++ b/src/View/Components/BaseComponent.php
@@ -75,9 +75,7 @@ abstract class BaseComponent extends Component
             ->instance()
             ->toArray();
 
-        // We merge scope with soft personalization
-        // changes, but we prioritize scope changes.
-        $merged = empty($scope) ? $soft : Arr::only(array_merge($soft, $scope), array_keys($scope));
+        $merged = empty($scope) ? $soft : Arr::only(array_merge($soft, $scope), array_keys($scope)); // We merge scope with soft personalization changes, but we prioritize scope changes.
 
         // Here we do a second merge, now with the original classes and
         // the result of the previous operation that will use scoped


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

The soft scoped personalization until now only supported scoped personalization via an array. With this PR we adapt this to support personalization using a class that must return an array and also receives as parameters the entire list of standard classes that come from the component.

Before

```blade
<x-input label="Name" wire:model="name" :personalize="[
    'input.wrapper' => [
        'remove' => [
            'rounded-md',
        ],
    ]
]" />
```

With this PR:

```blade
<x-input label="Name" wire:model="name" :personalize="\App\Support\ScopedInputPersonalization::class" />

<!-- The array method continue works -->
```

```php
class ScopedInputPersonalization
{
    public function __invoke(array $classes) : array 
    {
        return [
            'input.wrapper' => [
                'remove' => [
                    'rounded-md',
                ],
            ]
        ];
    }
}
```

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
