### PR TITLE
[1.x] Add `find-component` Command

### DIFF
--- a/src/Foundation/Console/FindComponentCommand.php
+++ b/src/Foundation/Console/FindComponentCommand.php
@@ -33,7 +33,7 @@ class FindComponentCommand extends Command
             ->keys()
             ->filter(fn ($component) => ! in_array($component, self::IGNORES));
 
-        $original = suggest('Select Component', $components->values()->toArray(), scroll: 10);
+        $original = suggest('Select Component', $components->values()->toArray());
 
         $process = new Process(['grep', '-rn', $this->prefix($original), resource_path('views')]);
 

--- a/src/Foundation/Console/FindComponentCommand.php
+++ b/src/Foundation/Console/FindComponentCommand.php
@@ -40,7 +40,7 @@ class FindComponentCommand extends Command
         try {
             $process->mustRun();
 
-            $this->format($process->getOutput(), $original);
+            $this->output($process->getOutput(), $original);
 
             return self::SUCCESS;
         } catch (ProcessFailedException) {
@@ -52,7 +52,7 @@ class FindComponentCommand extends Command
         return self::FAILURE;
     }
 
-    private function format(string $output, string $component): void
+    private function output(string $output, string $component): void
     {
         if (blank($output)) {
             return;

--- a/src/Foundation/Console/FindComponentCommand.php
+++ b/src/Foundation/Console/FindComponentCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace TallStackUi\Foundation\Console;
+
+use Exception;
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+use function Laravel\Prompts\select;
+
+class FindComponentCommand extends Command
+{
+    // List of components that should not be searched because
+    // they are child components or non-visible components.
+    private const IGNORES = [
+        'dropdown.items',
+        'floating',
+        'progress.circle',
+        'step.items',
+        'tab.items',
+        'wrapper.input',
+        'wrapper.radio',
+    ];
+
+    public $description = 'TallStackUI find component';
+
+    public $signature = 'tallstackui:find-component';
+
+    public function handle(): int
+    {
+        $components = collect(config('tallstackui.components'))
+            ->keys()
+            ->filter(fn ($component) => ! in_array($component, self::IGNORES));
+
+        $component = select('Select a component to find', $components->values()->toArray(), scroll: 10);
+        $component = $this->prefix($component);
+
+        $process = new Process(['grep', '-rn', $component, resource_path('views')]);
+
+        try {
+            $process->mustRun();
+
+            $this->format($process->getOutput());
+
+            return self::SUCCESS;
+        } catch (ProcessFailedException) {
+            $component = $this->prefix($component, true);
+
+            $this->components->error('The component ['.$component.'] was not found in use.');
+        } catch (Exception $exception) {
+            $this->components->error('Unexpected Error Occurred: '.$exception->getMessage());
+        }
+
+        return self::FAILURE;
+    }
+
+    private function format(string $output): void
+    {
+        if (empty($output)) {
+            return;
+        }
+
+        $lines = collect(explode(PHP_EOL, $output))->filter();
+        $total = count($lines);
+
+        $this->components->info('🎉 Found '.count($lines).' occurrences.');
+
+        foreach ($lines as $key => $line) {
+            preg_match('/^(.*?):(\d+):(.*)$/', $line, $matches);
+
+            if (blank($line) || count($matches) !== 4) {
+                continue;
+            }
+
+            $path = str($matches[1])->afterLast(base_path().'/')->value();
+            $number = $matches[2];
+
+            $this->line("File: <fg=green>{$path}</>");
+            $this->line("Line: <fg=yellow>{$number}</>");
+
+            // While we are not at the end line we add ---
+            // otherwise we just add a new line as a whitespace
+            if (($key + 1) < $total) {
+                $this->line(str_repeat('-', 3));
+            } else {
+                $this->newLine();
+            }
+        }
+    }
+
+    private function prefix(string $component, bool $remove = false): string
+    {
+        if (! ($prefix = config('tallstackui.prefix'))) {
+            return $component;
+        }
+
+        return match ($remove) {
+            true => str($component)->after($prefix)->value(),
+            default => $prefix.$component,
+        };
+    }
+}

--- a/src/TallStackUiServiceProvider.php
+++ b/src/TallStackUiServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use TallStackUi\Facades\TallStackUi as Facade;
+use TallStackUi\Foundation\Console\FindComponentCommand;
 use TallStackUi\Foundation\Console\SetupIconsCommand;
 use TallStackUi\Foundation\Console\SetupPrefixCommand;
 use TallStackUi\Foundation\Personalization\Personalization;
@@ -41,7 +42,11 @@ class TallStackUiServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->commands([SetupIconsCommand::class, SetupPrefixCommand::class]);
+        $this->commands([
+            SetupIconsCommand::class,
+            SetupPrefixCommand::class,
+            FindComponentCommand::class,
+        ]);
     }
 
     protected function registerComponentPersonalizations(): void


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

For large projects, the way we have to identify where certain components are in use is using IDE searches. With this PR we added a command called `find-component` that will help us find where certain components are being used, looking inside "resources/views".

### Demonstration & Notes:

![CleanShot 2024-06-14 at 12 14 49](https://github.com/tallstackui/tallstackui/assets/60591772/dd36b6db-fa5d-4c03-a724-d2a745f6306a)
