### PR TITLE
[1.x] Fixing Quantity of Occurrences of `find-component` Command

### DIFF
--- a/src/Foundation/Console/FindComponentCommand.php
+++ b/src/Foundation/Console/FindComponentCommand.php
@@ -36,13 +36,12 @@ class FindComponentCommand extends Command
 
         $original = suggest('Select Component', $components->values()->toArray(), required: true);
         $prefix = config('tallstackui.prefix');
+        $find = sprintf('<x-%s', $prefix ? $prefix.$original : $original);
 
         $process = new Process([
             'grep',
             '-rn',
-            // When prefix is set, we need to search
-            // for the component with the prefix
-            $prefix ? $prefix.$original : $original,
+            $find,
             resource_path('views'),
         ]);
 
@@ -72,11 +71,12 @@ class FindComponentCommand extends Command
         $this->components->info('🔍 Searching for ['.$component.'] component...');
 
         $lines = collect(explode(PHP_EOL, $output))
+            // We need to keep this here to remove possible empty lines
             ->filter()
-            // We need to ignore lines that contain </ because
-            // they are closing tags and not the actual component,
-            // like examples of </x-modal> and </x-slide>
-            ->filter(fn ($line) => ! str_contains($line, '</'));
+            // After that, need to ignore lines that contain
+            // </x- because they are closing tags and not the
+            // actual component, like examples of </x-modal> and </x-slide>
+            ->filter(fn ($line) => ! str_contains($line, '</x-'));
 
         $total = $lines->count();
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

Prior to this pull request, the `find-component` command does not consider the opening Blade component tag to count the occurrence of a component usage. Thus, words that match the component name can be counted as occurrences of the component. This PR fixes this problem by causing the search to occur by pattern: `<x-%s`

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
