### PR TITLE
[1.x] Table Header - Attribute to Output Unescaped

### DIFF
--- a/src/resources/views/components/table/index.blade.php
+++ b/src/resources/views/components/table/index.blade.php
@@ -53,7 +53,7 @@
                                             class="inline-flex cursor-pointer truncate"
                                             wire:click="$set('sort', {column: '{{ $head($header)['column'] }}', direction: '{{ $head($header)['direction'] }}' })"
                                         @endif>
-                                        @if ($header['unescaped'] ?? false)
+                                        @if (strip_tags($header['label']) !== $header['label'])
                                             {!! $header['label'] ?? '' !!}
                                         @else
                                             {{ $header['label'] ?? '' }}

--- a/src/resources/views/components/table/index.blade.php
+++ b/src/resources/views/components/table/index.blade.php
@@ -53,7 +53,7 @@
                                             class="inline-flex cursor-pointer truncate"
                                             wire:click="$set('sort', {column: '{{ $head($header)['column'] }}', direction: '{{ $head($header)['direction'] }}' })"
                                         @endif>
-                                        @if (strip_tags($header['label']) !== $header['label'])
+                                        @if ($header['unescaped'] ?? false)
                                             {!! $header['label'] ?? '' !!}
                                         @else
                                             {{ $header['label'] ?? '' }}

--- a/src/resources/views/components/table/index.blade.php
+++ b/src/resources/views/components/table/index.blade.php
@@ -53,7 +53,11 @@
                                             class="inline-flex cursor-pointer truncate"
                                             wire:click="$set('sort', {column: '{{ $head($header)['column'] }}', direction: '{{ $head($header)['direction'] }}' })"
                                         @endif>
-                                        {{ $header['label'] ?? '' }}
+                                        @if ($header['unescaped'] ?? false)
+                                            {!! $header['label'] ?? '' !!}
+                                        @else
+                                            {{ $header['label'] ?? '' }}
+                                        @endif
                                         @if ($livewire && $sortable($header) && $sorted($header))
                                             <x-dynamic-component :component="TallStackUi::component('icon')"
                                                                 :icon="TallStackUi::icon($head($header)['direction'] === 'desc' ? 'chevron-up' : 'chevron-down')"


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [X] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [X] I created a new branch on my fork for this pull request 
- [X] I ensure that the current tests are passing
- [X] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [X] Enhancements
- [ ] Bugfix

### Description:

In order to be able to insert something like a checkbox into the table header (to select all rows), there needs to be a way to insert unescaped HTML as the header name. I propose an `unescaped` property when defining column headers. Please feel free to modify the name to something else, such as `raw`.

### Demonstration & Notes:

When defining columns, the property would be used like this:

```
    public $headers = [
        ['index' => 'id', 'label' => '<input type="checkbox" wire:model.live="selectAll" class="align-middle ml-1.5" />', 'sortable' => false, 'unescaped' => true],
       // more columns
    ];
```