### PR TITLE
[1.x] Step Param - Allow Forward

### DIFF
--- a/src/View/Components/Step/Step.php
+++ b/src/View/Components/Step/Step.php
@@ -21,6 +21,7 @@ class Step extends BaseComponent implements Personalization
         public ?bool $helpers = false,
         public ?bool $navigate = false,
         public ?bool $navigatePrevious = false,
+        public ?bool $allowForward = true,
         public ?string $variation = null,
         #[SkipDebug]
         public ComponentSlot|string|null $finish = null,

--- a/src/resources/views/components/step/step.blade.php
+++ b/src/resources/views/components/step/step.blade.php
@@ -40,6 +40,7 @@
             <div>
                 <button type="button"
                         x-show="selected < steps.length"
+                        @if(!$allowForward) disabled @endif
                         x-on:click="selected++; $refs.buttons.dispatchEvent(new CustomEvent('change', {detail: {step: selected}}));"
                         dusk="tallstackui_step_next"
                         @class($personalize['button.wrapper'])>


### PR DESCRIPTION
### Checklist:

- [X] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [X] I created a new branch on my fork for this pull request 
- [X] I ensure that the current tests are passing
- [X] I added tests that prove this pull request is working

### What:

- [ ] Feature
- [X] Enhancements
- [ ] Bugfix

### Description:

In order to make wizard-like pages with the Step component, I would like to be able to control whether the Next button is enabled.

I'm not sure if this was the correct way to do this, or if perhaps there's a better way, but I was able to get it working in this way. Please feel free to direct me to an alternate way of achieving this!

### Demonstration & Notes:

This would work with a method on the Livewire component that would return a truthy value regarding whether forward navigation is currently allowable. If false, the Step component will disable the Next button.

```
<x-step wire:model.live="step" :allowForward="$this->allowForward()" helpers navigate-previous>
    <x-step.items step="1"
                  title="Starting"
                  description="Step One">
        Step one...
        <x-button wire:click="step1Done">Done</x-button>
    </x-step.items>
    <x-step.items step="2"
                  title="Advancing"
                  description="Step Two">
        Step two...
    </x-step.items>
    <x-step.items step="3"
                  title="Finishing"
                  description="Step Three">
        Step three... <b>finished!</b>
    </x-step.items>
</x-step>
```

```
class MyWizard extends Component
{
    public int $step = 1;
    public int $maxStep = 1;

    public function allowForward()
    {
        return $this->step < $this->maxStep;
    }

    public function step1Done()
    {
        $this->maxStep = 2;
    }

    // render, etc...
}
```