### PR TITLE
[1.x] Do Not Run PHP Commands in `setup-prefix` Command

### DIFF
--- a/src/Foundation/Console/SetupPrefixCommand.php
+++ b/src/Foundation/Console/SetupPrefixCommand.php
@@ -17,8 +17,9 @@ class SetupPrefixCommand extends Command
     public function handle(): int
     {
         $prefix = text('What prefix do you want to use for the TallStackUI components?', required: true, hint: 'Type null to remove the current prefix, if set.');
+        $null = $prefix === 'null';
 
-        if ($prefix === 'null' && config('tallstackui.prefix') === null) {
+        if ($null && blank(config('tallstackui.prefix'))) {
             $this->components->error('The prefix is already set to null.');
 
             return self::FAILURE;
@@ -30,12 +31,8 @@ class SetupPrefixCommand extends Command
             return self::FAILURE;
         }
 
-        Process::run([
-            'php artisan view:clear',
-            'php artisan config:clear',
-        ]);
-
-        $this->components->info('The prefix ['.$prefix.'] was successfully set up.');
+        $this->components->info($null ? 'The prefix was successfully removed.' : 'The prefix ['.$prefix.'] was successfully set up.');
+        $this->components->info('Please, run <options=bold,underscore>php artisan optimize:clear</> to clear the cache.');
 
         return self::SUCCESS;
     }


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

The `setup-prefix` command was built with the ability to automatically run `php artisan` commands after setting the component prefix, like `view:clear` and `config:clear`, but when the TSUI runs inside Docker, for example: Sail, we have exceptions when these commands are executed. With this PR we just change from the command to instructions to run the `php artisan optimize:clear` manually.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->

![CleanShot 2024-07-02 at 11 29 59](https://github.com/tallstackui/tallstackui/assets/60591772/4293e879-c66e-41f8-8094-ded98f1508c1)
