### PR TITLE
[1.x] Enhancements on Link Component

### DIFF
--- a/src/View/Components/Link.php
+++ b/src/View/Components/Link.php
@@ -28,6 +28,8 @@ class Link extends BaseComponent implements Personalization
         public ?bool $bold = null,
         public ?bool $underline = null,
         public ?bool $colorless = null,
+        public ?bool $navigate = null,
+        public ?bool $navigateHover = null,
         #[SkipDebug]
         public ?string $size = null,
         #[SkipDebug]

--- a/src/View/Components/Link.php
+++ b/src/View/Components/Link.php
@@ -35,6 +35,7 @@ class Link extends BaseComponent implements Personalization
         #[SkipDebug]
         public ?string $formatted = null,
     ) {
+        $this->text ??= $this->href;
         $this->size = $this->lg ? 'lg' : ($this->sm ? 'sm' : 'md');
 
         $this->formatted = $this->href;

--- a/src/resources/views/components/link.blade.php
+++ b/src/resources/views/components/link.blade.php
@@ -9,7 +9,7 @@
         $personalize['icon.base'] => $icon,
         $personalize['sizes.'.$size],
         $colors['text'] => !$colorless,
-    ]) }} @if ($blank) target="_blank" @endif>
+    ]) }} @if ($blank) target="_blank" @endif @if ($navigate) wire:navigate @elseif($navigateHover) wire:navigate.hover @endif>
     @if ($icon && $position === 'left')
         <x-dynamic-component :component="TallStackUi::component('icon')" :$icon @class($personalize['icon.size']) />
     @endif

--- a/src/resources/views/components/link.blade.php
+++ b/src/resources/views/components/link.blade.php
@@ -9,7 +9,7 @@
         $personalize['icon.base'] => $icon,
         $personalize['sizes.'.$size],
         $colors['text'] => !$colorless,
-    ]) }} @if ($blank) target="_blank" @endif @if ($navigate) wire:navigate @elseif($navigateHover) wire:navigate.hover @endif>
+    ]) }} @if ($blank) target="_blank" @endif @if ($navigate) wire:navigate @elseif ($navigateHover) wire:navigate.hover @endif>
     @if ($icon && $position === 'left')
         <x-dynamic-component :component="TallStackUi::component('icon')" :$icon @class($personalize['icon.size']) />
     @endif

--- a/tests/Feature/Components/Link/IndexTest.php
+++ b/tests/Feature/Components/Link/IndexTest.php
@@ -108,6 +108,18 @@ it('can render without color', function () {
         ->not->toContain('text-primary-500');
 });
 
+it('can render with wire:navigate')
+    ->expect('<x-link href="https://google.com.br" navigate />')
+    ->render()
+    ->toContain('<a href="https://google.com.br"')
+    ->toContain('wire:navigate');
+
+it('can render with wire:navigate.hover')
+    ->expect('<x-link href="https://google.com.br" navigate-hover />')
+    ->render()
+    ->toContain('<a href="https://google.com.br"')
+    ->toContain('wire:navigate.hover');
+
 it('cannot render without href', function () {
     $this->expectException(ViewException::class);
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [x] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

With this PR we introduce some enhancements to the Link component:

1. New attributes that make it easy to add `wire:navigate` or `wire:navigate.hover` in the links
2. Ability to set the link text using the href when text is null.

### Demonstration & Notes:

To add `wire:navigate` in the links:

```blade
<x-link ... navigate />
```

To add `wire:navigate.hover` in the links:

```blade
<x-link ... navigate-hover />
```