### PR TITLE
[1.x] Add support to use images on Avatar component

### DIFF
--- a/src/View/Components/Avatar.php
+++ b/src/View/Components/Avatar.php
@@ -17,6 +17,7 @@ class Avatar extends BaseComponent implements Personalization
         public ?Model $model = null,
         public ?string $text = null,
         public ?string $color = 'primary',
+        public ?string $image = null,
         public ?bool $xs = null,
         public ?bool $sm = null,
         public ?bool $md = null,
@@ -24,6 +25,7 @@ class Avatar extends BaseComponent implements Personalization
         public bool $square = false,
         public ?string $property = 'name',
         public ?string $background = '0D8ABC',
+        public ?bool $borderless = false,
         #[SkipDebug]
         public ?string $size = null,
         public ?array $options = [],

--- a/src/resources/views/components/avatar.blade.php
+++ b/src/resources/views/components/avatar.blade.php
@@ -4,17 +4,17 @@
 
 <div {{ $attributes->class([
         'rounded-full' => !$square,
-        'border-2' => !$model,
+        'border-2' => !$borderless && !$model,
         $personalize['wrapper.class'],
         $colors['background'] => !$model,
         $personalize['wrapper.sizes.' . $size],
     ]) }}>
-    @if ($model)
+    @if ($model || $image)
         <img @class([
             'rounded-full' => !$square,
             $personalize['content.image.class'],
             $personalize['content.image.sizes.' . $size],
-        ]) src="{{ $modelable() }}" alt="{{ $model->getAttribute($property ?? null) }}"/>
+        ]) src="{{ $image ?? $modelable() }}" alt="{{ $text ?? $model?->getAttribute($property ?? null) }}"/>
     @elseif ($text || $slot->isNotEmpty())
         <span @class([
                 $personalize['content.text.class'],

--- a/tests/Feature/Components/Avatar/IndexTest.php
+++ b/tests/Feature/Components/Avatar/IndexTest.php
@@ -30,3 +30,14 @@ it('can render placeholder')
     ->expect('<x-avatar />')
     ->render()
     ->toContain('svg');
+
+it('can render image')
+    ->expect('<x-avatar image="https://cdn.dribbble.com/users/17793/screenshots/16101765/media/beca221aaebf1d3ea7684ce067bc16e5.png" />')
+    ->render()
+    ->toContain('src="https://cdn.dribbble.com/users/17793/screenshots/16101765/media/beca221aaebf1d3ea7684ce067bc16e5.png"');
+
+it('can render image with alt')
+    ->expect('<x-avatar image="https://cdn.dribbble.com/users/17793/screenshots/16101765/media/beca221aaebf1d3ea7684ce067bc16e5.png" text="Beca" />')
+    ->render()
+    ->toContain('src="https://cdn.dribbble.com/users/17793/screenshots/16101765/media/beca221aaebf1d3ea7684ce067bc16e5.png"')
+    ->toContain('alt="Beca');


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

As part of an idea obtained here: https://github.com/tallstackui/tallstackui/discussions/574, this PR adds avatar support with images 👇🏻 Also with the addition of `borderless` that aims to hide the border.

### Demonstration & Notes:

```blade
<x-avatar image="https://..." />

<x-avatar image="https://..." text="Alt text goes here" />

<x-avatar image="https://..." text="Alt text goes here" borderless />
```