### PR TITLE
[1.x] Fix translation pagination message in the table

### DIFF
--- a/src/resources/views/components/table/paginators.blade.php
+++ b/src/resources/views/components/table/paginators.blade.php
@@ -45,13 +45,13 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
             <div class="hidden sm:flex sm:items-center sm:justify-between">
                 <div class="mr-4">
                     <p class="text-sm text-gray-700 dark:text-dark-300 leading-5">
-                        <span>{!! __('Showing') !!}</span>
+                        <span>{!! __('pagination.showing') !!}</span>
                         <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                        <span>{!! __('to') !!}</span>
+                        <span>{!! __('pagination.to') !!}</span>
                         <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                        <span>{!! __('of') !!}</span>
+                        <span>{!! __('pagination.of') !!}</span>
                         <span class="font-medium">{{ $paginator->total() }}</span>
-                        <span>{!! __('results') !!}</span>
+                        <span>{!! __('pagination.results') !!}</span>
                     </p>
                 </div>
                 <div>


### PR DESCRIPTION
### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

Correction in the translation of the message that shows the total results in the table, the name of the paging file was added before the value

### Demonstration & Notes:

Before
`<span>{!! __('Showing') !!}</span>`

After
`<span>{!! __('pagination.showing') !!}</span>`

