### PR TITLE
[1.x] Create Soft Personalization `width` for Dropdown Component

### DIFF
--- a/src/View/Components/Dropdown/Dropdown.php
+++ b/src/View/Components/Dropdown/Dropdown.php
@@ -40,6 +40,7 @@ class Dropdown extends BaseComponent implements Personalization
                 'second' => 'relative inline-block text-left',
                 'slot' => 'overflow-hidden rounded-md',
             ],
+            'width' => 'w-56',
             'floating' => collect(app(Floating::class)->personalization())->get('wrapper'),
             'action' => [
                 'wrapper' => 'inline-flex w-full gap-x-1.5',

--- a/src/resources/views/components/dropdown/dropdown.blade.php
+++ b/src/resources/views/components/dropdown/dropdown.blade.php
@@ -29,7 +29,7 @@
         @endif
         <x-dynamic-component :component="TallStackUi::component('floating')"
                              :floating="$personalize['floating']"
-                             class="w-56"
+                             :class="$personalize['width']"
                              offset="5"
                              :$position
                              x-anchor="$refs.dropdown">


### PR DESCRIPTION
…zation

<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

Relates to #592 . This PR aims only transform the `w-56` into a soft personalizable key called `width`/

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
