### PR TITLE
[1.x] Add Event on Tab Component Navigation

### DIFF
--- a/src/resources/views/components/tab/tab.blade.php
+++ b/src/resources/views/components/tab/tab.blade.php
@@ -2,8 +2,7 @@
     $personalize = $classes();
 @endphp
 
-<div x-data="{ selected: @if (!$selected) {!! TallStackUi::blade($attributes, $livewire)->entangle() !!} @else @js($selected) @endif, tabs: [] }"
-     @class($personalize['base.wrapper'])>
+<div x-data="{ selected: @if (!$selected) {!! TallStackUi::blade($attributes, $livewire)->entangle() !!} @else @js($selected) @endif, tabs: [] }" @class($personalize['base.wrapper'])>
     <div @class($personalize['base.padding'])>
         <select x-model="selected" @class($personalize['base.select'])>
             <template x-for="item in tabs">
@@ -11,10 +10,10 @@
             </template>
         </select>
     </div>
-    <ul @class($personalize['base.body'])>
+    <ul @class($personalize['base.body']) {{ $attributes->only('x-on:navigate') }} x-ref="ul">
         <template x-for="item in tabs">
             <li role="tab"
-                x-on:click="selected = item.tab"
+                x-on:click="selected = item.tab; $refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: item.tab}}));"
                 x-bind:class="{
                     '{{ $personalize['item.select'] }}' : selected === item.tab,
                     '{{ $personalize['item.unselect'] }}' : selected !== item.tab

--- a/tests/Browser/Tab/IndexTest.php
+++ b/tests/Browser/Tab/IndexTest.php
@@ -9,6 +9,41 @@ use Tests\Browser\BrowserTestCase;
 class IndexTest extends BrowserTestCase
 {
     /** @test */
+    public function can_dispatch_event(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public ?string $selected = null;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>        
+                    <p dusk="selected">{{ $selected }}</p>
+
+                    <x-tab selected="Foo" x-on:navigate="$wire.set('selected', $event.detail.select)">
+                        <x-tab.items tab="Foo">
+                            Foo bar baz
+                        </x-tab.items>
+                        <x-tab.items tab="Bar">
+                            Baz bar foo
+                        </x-tab.items>
+                    </x-tab>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSee('Foo')
+            ->assertSee('Bar')
+            ->assertSee('Foo bar baz')
+            ->assertDontSee('Baz bar foo')
+            ->clickAtXPath('/html/body/div[3]/div/ul/li[2]')
+            ->waitForText('Baz bar foo')
+            ->assertDontSee('Foo bar baz')
+            ->waitForTextIn('@selected', 'Bar');
+    }
+
+    /** @test */
     public function can_render_and_select_with_accents(): void
     {
         Livewire::visit(new class extends Component


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

This PR aims to add support for a navigation event in the Tab component.

### Demonstration & Notes:

```blade
<x-tab selected="Tab 1" x-on:navigate="alert($event.detail.select)">
    <x-tab.items tab="Tab 1">
        Tab 1
    </x-tab.items>
    <x-tab.items tab="Tab 2">
        Tab 2
    </x-tab.items>
    <x-tab.items tab="Tab 3">
        Tab 3
    </x-tab.items>
</x-tab>
```
