### PR TITLE
[1.x] Fixing `Undefined array key 0` in Select Components

### DIFF
--- a/src/View/Components/Select/Native.php
+++ b/src/View/Components/Select/Native.php
@@ -10,13 +10,13 @@ use TallStackUi\Foundation\Attributes\SoftPersonalization;
 use TallStackUi\Foundation\Personalization\Contracts\Personalization;
 use TallStackUi\View\Components\BaseComponent;
 use TallStackUi\View\Components\Form\Traits\DefaultInputClasses;
-use TallStackUi\View\Components\Select\Traits\InteractsWithSelectOptions;
+use TallStackUi\View\Components\Select\Traits\SetupSelects;
 
 #[SoftPersonalization('select.native')]
 class Native extends BaseComponent implements Personalization
 {
     use DefaultInputClasses;
-    use InteractsWithSelectOptions;
+    use SetupSelects;
 
     public function __construct(
         public ?string $label = null,
@@ -26,7 +26,7 @@ class Native extends BaseComponent implements Personalization
         public ?array $selectable = [],
         public ?bool $invalidate = null,
     ) {
-        $this->options();
+        $this->setup();
     }
 
     public function blade(): View

--- a/src/View/Components/Select/Styled.php
+++ b/src/View/Components/Select/Styled.php
@@ -14,15 +14,15 @@ use TallStackUi\Foundation\Traits\WireChangeEvent;
 use TallStackUi\View\Components\BaseComponent;
 use TallStackUi\View\Components\Floating;
 use TallStackUi\View\Components\Form\Traits\DefaultInputClasses;
-use TallStackUi\View\Components\Select\Traits\InteractsWithSelectOptions;
+use TallStackUi\View\Components\Select\Traits\SetupSelects;
 use Throwable;
 
 #[SoftPersonalization('select.styled')]
 class Styled extends BaseComponent implements Personalization
 {
     use DefaultInputClasses;
-    use InteractsWithSelectOptions;
     use SanitizePropertyValue;
+    use SetupSelects;
     use WireChangeEvent;
 
     /** @throws Throwable */
@@ -52,7 +52,7 @@ class Styled extends BaseComponent implements Personalization
         $this->common = ! filled($this->request);
         $this->searchable = $this->common ? $this->searchable : true;
 
-        $this->options();
+        $this->setup();
 
         if (is_array($this->request)) {
             $this->request['method'] ??= 'get';

--- a/src/View/Components/Select/Traits/SetupSelects.php
+++ b/src/View/Components/Select/Traits/SetupSelects.php
@@ -2,15 +2,11 @@
 
 namespace TallStackUi\View\Components\Select\Traits;
 
-use Illuminate\Support\Collection;
-
-trait InteractsWithSelectOptions
+trait SetupSelects
 {
-    private function options(): void
+    private function setup(): void
     {
-        $this->options = $this->options instanceof Collection
-            ? $this->options->toArray()
-            : $this->options;
+        $this->options = collect(array_values($this->options));
 
         if (! $this->select || ($this->options !== [] && ! is_array($this->options[0]))) {
             return;
@@ -20,7 +16,7 @@ trait InteractsWithSelectOptions
         $label = explode(':', $select[0])[1];
         $value = explode(':', $select[1])[1];
 
-        $this->options = collect($this->options)->map(fn (array $item) => [
+        $this->options = $this->options->map(fn (array $item) => [
             $label => $item[$label],
             $value => $item[$value],
             'disabled' => $item['disabled'] ?? false,
@@ -28,9 +24,6 @@ trait InteractsWithSelectOptions
             'image' => current(array_intersect_key($item, array_flip(['image', 'img', 'img_src']))) ?: null,
         ])->toArray();
 
-        $this->selectable = [
-            'label' => $label,
-            'value' => $value,
-        ];
+        $this->selectable = ['label' => $label, 'value' => $value];
     }
 }

--- a/src/View/Components/Select/Traits/SetupSelects.php
+++ b/src/View/Components/Select/Traits/SetupSelects.php
@@ -6,7 +6,7 @@ trait SetupSelects
 {
     private function setup(): void
     {
-        $this->options = collect(array_values($this->options));
+        $this->options = collect(array_values($this->options))->toArray();
 
         if (! $this->select || ($this->options !== [] && ! is_array($this->options[0]))) {
             return;
@@ -16,7 +16,7 @@ trait SetupSelects
         $label = explode(':', $select[0])[1];
         $value = explode(':', $select[1])[1];
 
-        $this->options = $this->options->map(fn (array $item) => [
+        $this->options = collect($this->options)->map(fn (array $item) => [
             $label => $item[$label],
             $value => $item[$value],
             'disabled' => $item['disabled'] ?? false,


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

A small fix for `Undefined array key 0` with the array is a list but does not have the `0` key.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
