### PR TITLE
[1.x] Split required dependencies from `laravel/framework`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,15 @@
     "require": {
         "php": "^8.1",
         "livewire/livewire": "^3.4.9",
-        "laravel/framework": "^10.0|^11.0"
+        "illuminate/console": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/pagination": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0",
+        "illuminate/view": "^10.0|^11.0"
     },
     "require-dev": {
         "pestphp/pest": "^2.0",
+        "laravel/framework": "^10.0|^11.0",
         "laravel/pint": "^1.13",
         "orchestra/testbench": "8.x-dev|9.x-dev",
         "orchestra/testbench-dusk": "8.x-dev|9.x-dev",
@@ -73,7 +78,9 @@
             "providers": [
                 "TallStackUi\\TallStackUiServiceProvider"
             ],
-            "aliases": []
+            "aliases": {
+                "TallStackUi": "TallStackUi\\Facades\\TallStackUi"
+            }
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     },
     "require-dev": {
         "pestphp/pest": "^2.0",
-        "laravel/framework": "^10.0|^11.0",
         "laravel/pint": "^1.13",
         "orchestra/testbench": "8.x-dev|9.x-dev",
         "orchestra/testbench-dusk": "8.x-dev|9.x-dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "200653a5b5b56dc475f84f0ca420dbcd",
+    "content-hash": "98f17e5723662aaaebc3b176112b6c2a",
     "packages": [
         {
             "name": "brick/math",
@@ -1377,16 +1377,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.5.1",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "ac815920de0eff6de947eac0a6a94e5ed0fb147c"
+                "reference": "df09d5b6a4188f8f3c3ab2e43a109076a5eeb767"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/ac815920de0eff6de947eac0a6a94e5ed0fb147c",
-                "reference": "ac815920de0eff6de947eac0a6a94e5ed0fb147c",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/df09d5b6a4188f8f3c3ab2e43a109076a5eeb767",
+                "reference": "df09d5b6a4188f8f3c3ab2e43a109076a5eeb767",
                 "shasum": ""
             },
             "require": {
@@ -1479,7 +1479,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-24T12:52:09+00:00"
+            "time": "2024-08-14T10:56:57+00:00"
         },
         {
             "name": "league/config",
@@ -6829,16 +6829,16 @@
         },
         {
             "name": "orchestra/dusk-updater",
-            "version": "v2.5.0",
+            "version": "v2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/dusk-updater.git",
-                "reference": "646e77b66caee92a7f497d6bcf05f5ea8090be87"
+                "reference": "0e63a1cb2dbc7379e7eefa90a397d1dbd864da3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/dusk-updater/zipball/646e77b66caee92a7f497d6bcf05f5ea8090be87",
-                "reference": "646e77b66caee92a7f497d6bcf05f5ea8090be87",
+                "url": "https://api.github.com/repos/orchestral/dusk-updater/zipball/0e63a1cb2dbc7379e7eefa90a397d1dbd864da3c",
+                "reference": "0e63a1cb2dbc7379e7eefa90a397d1dbd864da3c",
                 "shasum": ""
             },
             "require": {
@@ -6853,7 +6853,11 @@
                 "symfony/polyfill-php83": "^1.28",
                 "symfony/process": "^6.0 || ^7.0"
             },
+            "conflict": {
+                "laravel/dusk": "<6.0.0 || >=9.0.0"
+            },
             "require-dev": {
+                "laravel/dusk": "^6.0 || ^7.0 || ^8.0",
                 "laravel/pint": "^1.4",
                 "phpstan/phpstan": "^1.11",
                 "phpunit/phpunit": "^9.6"
@@ -6892,9 +6896,9 @@
             "description": "Updater for Laravel Dusk ChromeDriver binaries",
             "support": {
                 "issues": "https://github.com/orchestral/dusk-updater/issues",
-                "source": "https://github.com/orchestral/dusk-updater/tree/v2.5.0"
+                "source": "https://github.com/orchestral/dusk-updater/tree/v2.6.0"
             },
-            "time": "2024-07-24T15:11:29+00:00"
+            "time": "2024-08-14T03:24:56+00:00"
         },
         {
             "name": "orchestra/testbench",
@@ -6902,12 +6906,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench.git",
-                "reference": "e617364fd182a3a836eeee9a9d8cc8854bd24504"
+                "reference": "6084d0793bae571713e96d48557562bb8276aa7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench/zipball/e617364fd182a3a836eeee9a9d8cc8854bd24504",
-                "reference": "e617364fd182a3a836eeee9a9d8cc8854bd24504",
+                "url": "https://api.github.com/repos/orchestral/testbench/zipball/6084d0793bae571713e96d48557562bb8276aa7b",
+                "reference": "6084d0793bae571713e96d48557562bb8276aa7b",
                 "shasum": ""
             },
             "require": {
@@ -6915,8 +6919,8 @@
                 "fakerphp/faker": "^1.23",
                 "laravel/framework": "^11.11",
                 "mockery/mockery": "^1.6",
-                "orchestra/testbench-core": "^9.2.2",
-                "orchestra/workbench": "^9.4",
+                "orchestra/testbench-core": "^9.3",
+                "orchestra/workbench": "^9.5",
                 "php": "^8.2",
                 "phpunit/phpunit": "^10.5 || ^11.0.1",
                 "symfony/process": "^7.0",
@@ -6948,9 +6952,9 @@
             ],
             "support": {
                 "issues": "https://github.com/orchestral/testbench/issues",
-                "source": "https://github.com/orchestral/testbench/tree/9.x"
+                "source": "https://github.com/orchestral/testbench/tree/v9.3.0"
             },
-            "time": "2024-08-10T17:04:46+00:00"
+            "time": "2024-08-14T06:29:45+00:00"
         },
         {
             "name": "orchestra/testbench-core",
@@ -6958,12 +6962,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-core.git",
-                "reference": "3d786693fe13dc3a533e557aca136167811b5034"
+                "reference": "d66217119f326f82190a3638739a92a985ad73b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/3d786693fe13dc3a533e557aca136167811b5034",
-                "reference": "3d786693fe13dc3a533e557aca136167811b5034",
+                "url": "https://api.github.com/repos/orchestral/testbench-core/zipball/d66217119f326f82190a3638739a92a985ad73b3",
+                "reference": "d66217119f326f82190a3638739a92a985ad73b3",
                 "shasum": ""
             },
             "require": {
@@ -7040,7 +7044,7 @@
                 "issues": "https://github.com/orchestral/testbench/issues",
                 "source": "https://github.com/orchestral/testbench-core"
             },
-            "time": "2024-08-12T08:44:04+00:00"
+            "time": "2024-08-14T05:55:35+00:00"
         },
         {
             "name": "orchestra/testbench-dusk",
@@ -7048,19 +7052,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/testbench-dusk.git",
-                "reference": "4d47249bd23ab24fd2dadb4971c5e49641e083a2"
+                "reference": "3c90375d93b9e8ff8025997e330b280be61d8ff6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/testbench-dusk/zipball/4d47249bd23ab24fd2dadb4971c5e49641e083a2",
-                "reference": "4d47249bd23ab24fd2dadb4971c5e49641e083a2",
+                "url": "https://api.github.com/repos/orchestral/testbench-dusk/zipball/3c90375d93b9e8ff8025997e330b280be61d8ff6",
+                "reference": "3c90375d93b9e8ff8025997e330b280be61d8ff6",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.2",
                 "laravel/dusk": "^8.1",
                 "laravel/serializable-closure": "^1.0",
-                "orchestra/dusk-updater": "^2.4",
+                "orchestra/dusk-updater": "^2.6",
                 "orchestra/testbench": "9.x-dev",
                 "orchestra/testbench-core": "9.x-dev",
                 "php": "^8.2",
@@ -7068,7 +7072,7 @@
                 "symfony/polyfill-php83": "^1.28"
             },
             "require-dev": {
-                "laravel/pint": "^1.6",
+                "laravel/pint": "^1.17",
                 "laravel/tinker": "^2.9",
                 "phpstan/phpstan": "^1.11",
                 "phpunit/phpunit": "^10.5 || ^11.0"
@@ -7108,7 +7112,7 @@
                 "issues": "https://github.com/orchestral/testbench-dusk/issues",
                 "source": "https://github.com/orchestral/testbench-dusk/tree/9.x"
             },
-            "time": "2024-07-13T08:35:04+00:00"
+            "time": "2024-08-14T07:38:08+00:00"
         },
         {
             "name": "orchestra/workbench",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98f17e5723662aaaebc3b176112b6c2a",
+    "content-hash": "32af0fe074b4730c402670be82c37895",
     "packages": [
         {
             "name": "brick/math",

--- a/src/TallStackUiServiceProvider.php
+++ b/src/TallStackUiServiceProvider.php
@@ -2,10 +2,8 @@
 
 namespace TallStackUi;
 
-use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
-use TallStackUi\Facades\TallStackUi as Facade;
 use TallStackUi\Foundation\Console\FindComponentCommand;
 use TallStackUi\Foundation\Console\SetupIconsCommand;
 use TallStackUi\Foundation\Console\SetupPrefixCommand;
@@ -32,8 +30,6 @@ class TallStackUiServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton('TallStackUi', TallStackUi::class);
-
-        AliasLoader::getInstance()->alias('TallStackUi', Facade::class);
     }
 
     protected function registerCommands(): void

--- a/tests/Browser/BrowserTestCase.php
+++ b/tests/Browser/BrowserTestCase.php
@@ -9,6 +9,7 @@ use Laravel\Dusk\Browser;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\Dusk\Options;
 use Orchestra\Testbench\Dusk\TestCase;
+use TallStackUi\Facades\TallStackUi;
 use TallStackUi\TallStackUiServiceProvider;
 
 use function Livewire\trigger;
@@ -56,6 +57,13 @@ class BrowserTestCase extends TestCase
             ]);
             $config->set('cache.default', 'array');
         });
+    }
+
+    protected function getPackageAliases($app)
+    {
+        return [
+            'TallStackUi' => TallStackUi::class,
+        ];
     }
 
     protected function getPackageProviders($app): array

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,9 +5,17 @@ namespace Tests;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use TallStackUi\Facades\TallStackUi;
 
 abstract class TestCase extends BaseTestCase
 {
     use InteractsWithViews;
     use WithWorkbench;
+
+    protected function getPackageAliases($app)
+    {
+        return [
+            'TallStackUi' => TallStackUi::class,
+        ];
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

This PR removes the hard dependency on `laravel/framework` instead requiring the individual Illuminate components that the package requires to function.

I understand this may not be appealing but it would greatly improve compatibility with Laravel-powered frameworks such as [Acorn](https://github.com/roots/acorn) and [Laracord](https://github.com/laracord/framework) which conflict with `laravel/framework` directly but otherwise can use this package the same as vanilla Laravel and benefit from all the awesome-ness it brings.

### Demonstration & Notes:

The only caveat I found while doing this is while both the projects above otherwise have `Illuminate\Foundation\AliasLoader` available – it wouldn't technically be included/required by this package so I have moved alias loading to `composer.json` and updated tests to work with the Facade.

~~I have moved `laravel/framework` to a dev-dependency for coverage but I believe the only dependency missing from the standalone Illuminate dependencies when testing is `illuminate/http`.~~ 

**Edit**: I removed the above since `orchestral/testbench` already brings in `laravel/framework`.