### PR TITLE
[1.x] Fixing `array_values(): Argument #1 ($array) must be of type array, Illuminate\Database\Eloquent\Collection given`

### DIFF
--- a/src/View/Components/Select/Traits/SetupSelects.php
+++ b/src/View/Components/Select/Traits/SetupSelects.php
@@ -2,11 +2,15 @@
 
 namespace TallStackUi\View\Components\Select\Traits;
 
+use Illuminate\Support\Collection;
+
 trait SetupSelects
 {
     private function setup(): void
     {
-        $this->options = collect(array_values($this->options))->toArray();
+        $this->options = $this->options instanceof Collection
+            ? $this->options->values()->toArray()
+            : array_values($this->options);
 
         if (! $this->select || ($this->options !== [] && ! is_array($this->options[0]))) {
             return;


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

Relates to #616 

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
