### PR TITLE
[1.x] Use trans() instead of __(

### DIFF
--- a/src/Actions/Dialog.php
+++ b/src/Actions/Dialog.php
@@ -101,8 +101,8 @@ class Dialog extends AbstractInteraction
     protected function messages(): array
     {
         return [
-            __('tallstack-ui::messages.dialog.button.confirm'),
-            __('tallstack-ui::messages.dialog.button.cancel'),
+            trans('tallstack-ui::messages.dialog.button.confirm'),
+            trans('tallstack-ui::messages.dialog.button.cancel'),
         ];
     }
 }

--- a/src/Actions/Toast.php
+++ b/src/Actions/Toast.php
@@ -135,8 +135,8 @@ class Toast extends AbstractInteraction
     protected function messages(): array
     {
         return [
-            __('tallstack-ui::messages.toast.button.confirm'),
-            __('tallstack-ui::messages.toast.button.cancel'),
+            trans('tallstack-ui::messages.toast.button.confirm'),
+            trans('tallstack-ui::messages.toast.button.cancel'),
         ];
     }
 }

--- a/src/View/Components/Clipboard.php
+++ b/src/View/Components/Clipboard.php
@@ -28,7 +28,7 @@ class Clipboard extends BaseComponent implements Personalization
         #[SkipDebug]
         public ?string $type = null,
     ) {
-        $this->placeholders = __('tallstack-ui::messages.clipboard');
+        $this->placeholders = trans('tallstack-ui::messages.clipboard');
 
         $this->type = $this->icon ? 'icon' : 'input';
 
@@ -86,7 +86,7 @@ class Clipboard extends BaseComponent implements Personalization
     /** @throws InvalidArgumentException */
     protected function validate(): void
     {
-        $messages = __('tallstack-ui::messages.clipboard');
+        $messages = trans('tallstack-ui::messages.clipboard');
 
         if (blank(data_get($messages, 'button.copy'))) {
             throw new InvalidArgumentException('The clipboard [button.copy] message cannot be empty.');

--- a/src/View/Components/Errors.php
+++ b/src/View/Components/Errors.php
@@ -21,7 +21,7 @@ class Errors extends BaseComponent implements Personalization
         public bool $close = false,
         public ComponentSlot|string|null $footer = null,
     ) {
-        $this->title ??= __('tallstack-ui::messages.errors.title');
+        $this->title ??= trans('tallstack-ui::messages.errors.title');
     }
 
     public function blade(): View

--- a/src/View/Components/Form/Upload.php
+++ b/src/View/Components/Form/Upload.php
@@ -32,8 +32,8 @@ class Upload extends BaseComponent implements Personalization
         public ?ComponentSlot $footer = null,
         public ?bool $overflow = null,
     ) {
-        $this->placeholder ??= __('tallstack-ui::messages.upload.placeholder');
-        $this->error ??= __('tallstack-ui::messages.upload.error');
+        $this->placeholder ??= trans('tallstack-ui::messages.upload.placeholder');
+        $this->error ??= trans('tallstack-ui::messages.upload.error');
     }
 
     /** @throws Exception */

--- a/src/View/Components/Interaction/Dialog.php
+++ b/src/View/Components/Interaction/Dialog.php
@@ -49,7 +49,7 @@ class Dialog extends BaseComponent implements Personalization
     /** @throws InvalidArgumentException */
     protected function validate(): void
     {
-        $messages = __('tallstack-ui::messages.dialog.button');
+        $messages = trans('tallstack-ui::messages.dialog.button');
 
         if (! str(config('tallstackui.settings.dialog.z-index', 'z-50'))->startsWith('z-')) {
             throw new InvalidArgumentException('The dialog z-index must start with z- prefix');

--- a/src/View/Components/Interaction/Toast.php
+++ b/src/View/Components/Interaction/Toast.php
@@ -64,7 +64,7 @@ class Toast extends BaseComponent implements Personalization
     {
         $configuration = collect(config('tallstackui.settings.toast'));
         $positions = ['top-right', 'top-left', 'bottom-right', 'bottom-left'];
-        $messages = __('tallstack-ui::messages.toast.button');
+        $messages = trans('tallstack-ui::messages.toast.button');
 
         if (! in_array($configuration->get('position', 'top-right'), $positions)) {
             throw new InvalidArgumentException('The toast position must be one of the following: ['.implode(', ', $positions).']');

--- a/src/View/Components/Select/Styled.php
+++ b/src/View/Components/Select/Styled.php
@@ -46,7 +46,7 @@ class Styled extends BaseComponent implements Personalization
         #[SkipDebug]
         public ?bool $common = true,
     ) {
-        $this->placeholders ??= [...__('tallstack-ui::messages.select')];
+        $this->placeholders ??= [...trans('tallstack-ui::messages.select')];
         $this->placeholder ??= data_get($this->placeholders, 'default');
 
         $this->common = ! filled($this->request);

--- a/src/View/Components/Table.php
+++ b/src/View/Components/Table.php
@@ -50,7 +50,7 @@ class Table extends BaseComponent implements Personalization
         #[SkipDebug]
         public ComponentSlot|string|null $footer = null
     ) {
-        $this->placeholders = __('tallstack-ui::messages.table');
+        $this->placeholders = trans('tallstack-ui::messages.table');
 
         if (is_bool($filter) && $this->filter === true) {
             $this->filter = ['quantity' => 'quantity', 'search' => 'search'];
@@ -153,7 +153,7 @@ class Table extends BaseComponent implements Personalization
     /** @throws InvalidArgumentException */
     protected function validate(): void
     {
-        $messages = __('tallstack-ui::messages.table');
+        $messages = trans('tallstack-ui::messages.table');
 
         if (blank($messages['empty'] ?? null)) {
             throw new InvalidArgumentException('The table [empty] message cannot be empty.');

--- a/src/resources/views/components/errors.blade.php
+++ b/src/resources/views/components/errors.blade.php
@@ -17,7 +17,7 @@
                                              :icon="TallStackUi::icon($icon)"
                                              class="w-5 h-5" outline />
                     @endif
-                    {{ __($title, ['count' => $count($errors)]) }}
+                    {{ trans($title, ['count' => $count($errors)]) }}
                 </span>
                 @if ($close)
                 <button dusk="errors-close-button"

--- a/src/resources/views/components/form/date.blade.php
+++ b/src/resources/views/components/form/date.blade.php
@@ -20,7 +20,7 @@
      @js($property),
      @js($value),
      @js($monthYearOnly),
-     @js(__('tallstack-ui::messages.date.calendar')),
+     @js(trans('tallstack-ui::messages.date.calendar')),
      @js($change($attributes, $__livewire ?? null, $livewire)))"
      x-cloak x-on:click.outside="show = false">
     <x-dynamic-component :component="TallStackUi::component('input')"
@@ -67,7 +67,7 @@
                                 <span x-text="calendar.months[month]" @class($personalize['label.month'])></span>
                             </button>
                             <button type="button" class="mr-2" x-on:click="now()" x-show="!monthYearOnly">
-                                {{ __('tallstack-ui::messages.date.helpers.today') }}
+                                {{ trans('tallstack-ui::messages.date.helpers.today') }}
                             </button>
                         </div>
                         <template x-for="(months, index) in calendar.months" :key="index">
@@ -91,7 +91,7 @@
                                 <span x-text="range.year.last" @class($personalize['label.month'])></span>
                             </div>
                             <button type="button" x-on:click="now()" x-show="!monthYearOnly">
-                                {{ __('tallstack-ui::messages.date.helpers.today') }}
+                                {{ trans('tallstack-ui::messages.date.helpers.today') }}
                             </button>
                             <div>
                                 <button type="button"
@@ -201,7 +201,7 @@
                                 dusk="tallstackui_date_helper_{{ $helper }}"
                                 x-on:click="helper($event, @js($helper))"
                                 @class($personalize['button.helpers'])>
-                            {{ __('tallstack-ui::messages.date.helpers.' . $helper) }}
+                            {{ trans('tallstack-ui::messages.date.helpers.' . $helper) }}
                         </button>
                     @endforeach
                 </div>

--- a/src/resources/views/components/form/password.blade.php
+++ b/src/resources/views/components/form/password.blade.php
@@ -54,7 +54,7 @@
                              :floating="$personalize['floating']"
                              class="w-full p-3"
                              x-show="rules">
-            <h3 @class($personalize['rules.title'])>{{ __('tallstack-ui::messages.password.rules.title') }}</h3>
+            <h3 @class($personalize['rules.title'])>{{ trans('tallstack-ui::messages.password.rules.title') }}</h3>
             <div @class($personalize['rules.block'])>
                 @if ($rules->has('min'))
                     <span @class($personalize['rules.items.base'])>
@@ -66,7 +66,7 @@
                                                  :icon="$icon['check-circle']"
                                                  :class="$personalize['rules.items.icons.success']"
                                                  x-show="results.min" />
-                            <p x-bind:class="{ 'line-through' : results.min }">{{ __('tallstack-ui::messages.password.rules.formats.min', ['min' => $rules->get('min')]) }}</p>
+                            <p x-bind:class="{ 'line-through' : results.min }">{{ trans('tallstack-ui::messages.password.rules.formats.min', ['min' => $rules->get('min')]) }}</p>
                         </span>
                 @endif
                 @if ($rules->has('symbols'))
@@ -79,7 +79,7 @@
                                                  :icon="$icon['check-circle']"
                                                  :class="$personalize['rules.items.icons.success']"
                                                  x-show="results.symbols" />
-                            <p x-bind:class="{ 'line-through' : results.symbols }">{{ __('tallstack-ui::messages.password.rules.formats.symbols', ['symbols' => $rules->get('symbols')]) }}</p>
+                            <p x-bind:class="{ 'line-through' : results.symbols }">{{ trans('tallstack-ui::messages.password.rules.formats.symbols', ['symbols' => $rules->get('symbols')]) }}</p>
                         </span>
                 @endif
                 @if ($rules->has('numbers'))
@@ -92,7 +92,7 @@
                                                  :icon="$icon['check-circle']"
                                                  :class="$personalize['rules.items.icons.success']"
                                                  x-show="results.numbers" />
-                            <p x-bind:class="{ 'line-through' : results.numbers }">{{ __('tallstack-ui::messages.password.rules.formats.numbers') }}</p>
+                            <p x-bind:class="{ 'line-through' : results.numbers }">{{ trans('tallstack-ui::messages.password.rules.formats.numbers') }}</p>
                         </span>
                 @endif
                 @if ($rules->has('mixed'))
@@ -105,7 +105,7 @@
                                                  :icon="$icon['check-circle']"
                                                  :class="$personalize['rules.items.icons.success']"
                                                  x-show="results.mixed" />
-                            <p x-bind:class="{ 'line-through' : results.mixed }">{{ __('tallstack-ui::messages.password.rules.formats.mixed') }}</p>
+                            <p x-bind:class="{ 'line-through' : results.mixed }">{{ trans('tallstack-ui::messages.password.rules.formats.mixed') }}</p>
                         </span>
                 @endif
             </div>

--- a/src/resources/views/components/form/time.blade.php
+++ b/src/resources/views/components/form/time.blade.php
@@ -105,7 +105,7 @@
             <x-slot:footer>
                 @if ($helper)
                 <x-dynamic-component :component="TallStackUi::component('button')"
-                                     :text="__('tallstack-ui::messages.time.helper')"
+                                     :text="trans('tallstack-ui::messages.time.helper')"
                                      type="button"
                                      @class([$personalize['helper.button'], 'mt-2' => $format === '24'])
                                      x-on:click="current()"

--- a/src/resources/views/components/form/upload.blade.php
+++ b/src/resources/views/components/form/upload.blade.php
@@ -12,7 +12,7 @@
         @js($error),
         @js($static),
         @js($placeholder),
-        @js(__('tallstack-ui::messages.upload.uploaded')),
+        @js(trans('tallstack-ui::messages.upload.uploaded')),
         @js($overflow))"
      x-cloak
      x-on:livewire-upload-start="uploading = true"
@@ -43,7 +43,7 @@
         </x-dynamic-component>
     @if ($preview)
         <template x-teleport="body">
-            <div x-show="preview" 
+            <div x-show="preview"
                  x-on:click="preview = false; $nextTick(() => show = true)"
                  x-transition:enter="ease-out duration-300"
                  x-transition:enter-start="opacity-0"
@@ -75,7 +75,7 @@
                                           :icon="TallStackUi::icon('cloud-arrow-up')"
                                           @class($personalize['placeholder.icon.class']) />
                      <p @class($personalize['placeholder.title'])>
-                         {{ __('tallstack-ui::messages.upload.upload') }}
+                         {{ trans('tallstack-ui::messages.upload.upload') }}
                      </p>
                  </div>
                  @if (is_string($tip))
@@ -127,7 +127,7 @@
                                                           :property="is_array($value) ? $property . '.' . $key : $property" />
                                      @if ($file['size'] !== null)
                                          <p @class($personalize['item.size'])>
-                                             <span>{{ __('tallstack-ui::messages.upload.size') }}: </span>
+                                             <span>{{ trans('tallstack-ui::messages.upload.size') }}: </span>
                                              <span>{{ $file['size'] }}</span>
                                          </p>
                                      @endif
@@ -154,10 +154,10 @@
                                       :icon="TallStackUi::icon('photo')"
                                       :class="$personalize['static.empty.icon']" />
                  <h3 @class($personalize['static.empty.title'])>
-                     {{ __('tallstack-ui::messages.upload.static.empty.title') }}
+                     {{ trans('tallstack-ui::messages.upload.static.empty.title') }}
                  </h3>
                  <p @class($personalize['static.empty.description'])>
-                     {{ __('tallstack-ui::messages.upload.static.empty.description') }}
+                     {{ trans('tallstack-ui::messages.upload.static.empty.description') }}
                  </p>
              </div>
          @endif

--- a/src/resources/views/components/interaction/dialog.blade.php
+++ b/src/resources/views/components/interaction/dialog.blade.php
@@ -4,7 +4,7 @@
 @endphp
 
 <div x-cloak
-     x-data="tallstackui_dialog(@js($flash), @js(__('tallstack-ui::messages.dialog.button')), @js($configurations['overflow'] ?? false))"
+     x-data="tallstackui_dialog(@js($flash), @js(trans('tallstack-ui::messages.dialog.button')), @js($configurations['overflow'] ?? false))"
      x-on:tallstackui:dialog.window="add($event.detail)"
      @class(['relative', $configurations['z-index']])
      aria-labelledby="modal-title"

--- a/src/resources/views/components/step/step.blade.php
+++ b/src/resources/views/components/step/step.blade.php
@@ -2,10 +2,10 @@
     $personalize = $classes();
 @endphp
 
-<div x-data="{ 
-        selected: @if (!$selected) {!! TallStackUi::blade($attributes, $livewire)->entangle() !!} @else @js($selected) @endif, 
-        navigate: @js($navigate), 
-        previous: @js($navigatePrevious), 
+<div x-data="{
+        selected: @if (!$selected) {!! TallStackUi::blade($attributes, $livewire)->entangle() !!} @else @js($selected) @endif,
+        navigate: @js($navigate),
+        previous: @js($navigatePrevious),
         steps: [],
     }">
     <nav @if ($variation === 'panels') class="overflow-hidden rounded-md" @endif>
@@ -33,7 +33,7 @@
                         <x-dynamic-component :component="TallStackUi::component('icon')"
                                              :icon="TallStackUi::icon('chevron-left')"
                                              @class(['mr-1', $personalize['button.icon']]) />
-                        {{ __('tallstack-ui::messages.step.previous') }}
+                        {{ trans('tallstack-ui::messages.step.previous') }}
                     </button>
                 @endif
             </div>
@@ -43,7 +43,7 @@
                         x-on:click="selected++; $refs.buttons.dispatchEvent(new CustomEvent('change', {detail: {step: selected}}));"
                         dusk="tallstackui_step_next"
                         @class($personalize['button.wrapper'])>
-                    {{ __('tallstack-ui::messages.step.next') }}
+                    {{ trans('tallstack-ui::messages.step.next') }}
                     <x-dynamic-component :component="TallStackUi::component('icon')"
                                          :icon="TallStackUi::icon('chevron-right')"
                                          @class(['ml-1', $personalize['button.icon']]) />
@@ -60,7 +60,7 @@
                                 dusk="tallstackui_step_finish"
                                 {{ $attributes->only('x-on:finish') }}
                                 @class($personalize['button.wrapper'])>
-                            {{ __('tallstack-ui::messages.step.finish') }}
+                            {{ trans('tallstack-ui::messages.step.finish') }}
                         </button>
                     @endif
                 @endif

--- a/src/resources/views/components/table/paginators.blade.php
+++ b/src/resources/views/components/table/paginators.blade.php
@@ -20,22 +20,22 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                 <span>
                     @if ($paginator->onFirstPage())
                         <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-400 dark:text-dark-500 bg-gray-100 dark:bg-dark-700 border border-gray-200 dark:border-transparent cursor-default leading-5 rounded-md select-none cursor-pointer">
-                            {!! __('pagination.previous') !!}
+                            {!! trans('pagination.previous') !!}
                         </span>
                     @else
                         <button type="button" wire:click="previousPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" dusk="previousPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}.before" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 dark:text-dark-300 bg-white dark:bg-dark-600 border border-gray-300 dark:border-transparent leading-5 rounded-md select-none cursor-pointer">
-                            {!! __('pagination.previous') !!}
+                            {!! trans('pagination.previous') !!}
                         </button>
                     @endif
                 </span>
                 <span>
                     @if ($paginator->hasMorePages())
                         <button type="button" wire:click="nextPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" dusk="nextPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}.before" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 dark:text-dark-300 bg-white dark:bg-dark-600 border border-gray-300 dark:border-transparent leading-5 rounded-md select-none cursor-pointer">
-                            {!! __('pagination.next') !!}
+                            {!! trans('pagination.next') !!}
                         </button>
                     @else
                         <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-400 dark:text-dark-500 bg-gray-100 dark:bg-dark-700 border border-gray-200 dark:border-transparent cursor-default leading-5 rounded-md select-none cursor-pointer">
-                            {!! __('pagination.next') !!}
+                            {!! trans('pagination.next') !!}
                         </span>
                     @endif
                 </span>
@@ -45,13 +45,13 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
             <div class="hidden sm:flex sm:items-center sm:justify-between">
                 <div class="mr-4">
                     <p class="text-sm text-gray-700 dark:text-dark-300 leading-5">
-                        <span>{!! __('Showing') !!}</span>
+                        <span>{!! trans('Showing') !!}</span>
                         <span class="font-medium">{{ $paginator->firstItem() }}</span>
-                        <span>{!! __('to') !!}</span>
+                        <span>{!! trans('to') !!}</span>
                         <span class="font-medium">{{ $paginator->lastItem() }}</span>
-                        <span>{!! __('of') !!}</span>
+                        <span>{!! trans('of') !!}</span>
                         <span class="font-medium">{{ $paginator->total() }}</span>
-                        <span>{!! __('results') !!}</span>
+                        <span>{!! trans('results') !!}</span>
                     </p>
                 </div>
                 <div>
@@ -59,7 +59,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                         <!-- Previous Page Link -->
                         <span>
                             @if ($paginator->onFirstPage())
-                                <span aria-disabled="true" aria-label="{{ __('pagination.previous') }}">
+                                <span aria-disabled="true" aria-label="{{ trans('pagination.previous') }}">
                                     <span class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-300 dark:text-dark-500 bg-gray-100 dark:bg-dark-700 border border-gray-300 dark:border-transparent cursor-default rounded-l-md leading-5 focus:outline-none" aria-hidden="true">
                                         <x-dynamic-component :component="TallStackUi::component('icon')"
                                                              :icon="TallStackUi::icon('chevron-left')"
@@ -67,7 +67,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                                     </span>
                                 </span>
                             @else
-                                <button type="button" wire:click="previousPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" dusk="previousPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}.after" rel="prev" class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 dark:text-dark-300 bg-white dark:bg-dark-600 border border-gray-300 dark:border-transparent rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150" aria-label="{{ __('pagination.previous') }}">
+                                <button type="button" wire:click="previousPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" dusk="previousPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}.after" rel="prev" class="relative inline-flex items-center px-2 py-2 text-sm font-medium text-gray-500 dark:text-dark-300 bg-white dark:bg-dark-600 border border-gray-300 dark:border-transparent rounded-l-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150" aria-label="{{ trans('pagination.previous') }}">
                                     <x-dynamic-component :component="TallStackUi::component('icon')"
                                                          :icon="TallStackUi::icon('chevron-left')"
                                                          class="w-5 h-5" />
@@ -93,7 +93,7 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                                                 </span>
                                             </span>
                                         @else
-                                            <button type="button" wire:click="gotoPage({{ $page }}, '{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-600 dark:text-dark-400 bg-white dark:bg-dark-600 border border-gray-300 dark:border-transparent leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                                            <button type="button" wire:click="gotoPage({{ $page }}, '{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-600 dark:text-dark-400 bg-white dark:bg-dark-600 border border-gray-300 dark:border-transparent leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150" aria-label="{{ trans('Go to page :page', ['page' => $page]) }}">
                                                 {{ $page }}
                                             </button>
                                         @endif
@@ -104,13 +104,13 @@ $scrollIntoViewJsSnippet = ($scrollTo !== false)
                         <span>
                             <!-- Next Page Link -->
                             @if ($paginator->hasMorePages())
-                                <button type="button" wire:click="nextPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" dusk="nextPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}.after" rel="next" class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 dark:text-dark-300 bg-white dark:bg-dark-600 border border-gray-300 dark:border-transparent rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150" aria-label="{{ __('pagination.next') }}">
+                                <button type="button" wire:click="nextPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" dusk="nextPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}.after" rel="next" class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-500 dark:text-dark-300 bg-white dark:bg-dark-600 border border-gray-300 dark:border-transparent rounded-r-md leading-5 hover:text-gray-400 focus:z-10 focus:outline-none focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500 transition ease-in-out duration-150" aria-label="{{ trans('pagination.next') }}">
                                     <x-dynamic-component :component="TallStackUi::component('icon')"
                                                          :icon="TallStackUi::icon('chevron-right')"
                                                          class="w-5 h-5" />
                                 </button>
                             @else
-                                <span aria-disabled="true" aria-label="{{ __('pagination.next') }}">
+                                <span aria-disabled="true" aria-label="{{ trans('pagination.next') }}">
                                     <span class="relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium text-gray-300 dark:text-dark-500 bg-gray-100 dark:bg-dark-700 border border-gray-300 dark:border-transparent cursor-default rounded-r-md leading-5" aria-hidden="true">
                                         <x-dynamic-component :component="TallStackUi::component('icon')"
                                                              :icon="TallStackUi::icon('chevron-right')"

--- a/tests/Feature/Components/Form/PasswordTest.php
+++ b/tests/Feature/Components/Form/PasswordTest.php
@@ -28,11 +28,11 @@ it('can render with rules', function () {
 
     expect($component)
         ->render()
-        ->toContain(__('tallstack-ui::messages.password.rules.title'))
-        ->toContain(__('tallstack-ui::messages.password.rules.formats.min', ['min' => Password::defaults()['min']]))
-        ->toContain(__('tallstack-ui::messages.password.rules.formats.symbols', ['symbols' => '!@#']))
-        ->toContain(__('tallstack-ui::messages.password.rules.formats.numbers'))
-        ->toContain(__('tallstack-ui::messages.password.rules.formats.mixed'));
+        ->toContain(trans('tallstack-ui::messages.password.rules.title'))
+        ->toContain(trans('tallstack-ui::messages.password.rules.formats.min', ['min' => Password::defaults()['min']]))
+        ->toContain(trans('tallstack-ui::messages.password.rules.formats.symbols', ['symbols' => '!@#']))
+        ->toContain(trans('tallstack-ui::messages.password.rules.formats.numbers'))
+        ->toContain(trans('tallstack-ui::messages.password.rules.formats.mixed'));
 });
 
 it('cannot render with generator and without rules', function () {


### PR DESCRIPTION
### Checklist:

- [v] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [v] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working


### What:

- [ ] Feature
- [ ] Enhancements
- [v] Bugfix

### Description:

This pull request suggests a slightly different method to load the optional translation strings. Since the __( function (whilst shorter) is usually used by packages, in the Acorn package it conflicts with another global helper used by WordPress Core with the same name. 

The Laravel trans() function behaves exactly the same as __( but actually also comes with some helpers for plural strings as well. See https://laravel.com/docs/11.x/localization

**Example use cases**
After defining a translation string that has pluralization options, you may use the trans_choice function to retrieve the line for a given "count". In this example, since the count is greater than one, the plural form of the translation string is returned:

`echo trans_choice('messages.apples', 10);`

You may also define placeholder attributes in pluralization strings. These placeholders may be replaced by passing an array as the third argument to the trans_choice function:
`
'minutes_ago' => '{1} :value minute ago|[2,*] :value minutes ago',`
 
echo trans_choice('time.minutes_ago', 5, ['value' => 5]);
You may also define placeholder attributes in pluralization strings. These placeholders may be replaced by passing an array as the third argument to the trans_choice function:

```
'minutes_ago' => '{1} :value minute ago|[2,*] :value minutes ago',
 
echo trans_choice('time.minutes_ago', 5, ['value' => 5]);
```

### Demonstration & Notes:

This simple pull requests updates the function to output the strings across the components that uses them, and I tested all of them to ensure nothing changed. I also considered a global helper ts__( that would automatically pre-fix all strings with the "tallstack-ui::messages." prefix to easy access. But I kept it out of this initial request. Could be a good idea for the future :-) 

Please let me know what you think!