### PR TITLE
[1.x] Add Support for `required` in Pin Component

### DIFF
--- a/src/resources/views/components/form/pin.blade.php
+++ b/src/resources/views/components/form/pin.blade.php
@@ -3,6 +3,7 @@
     $personalize = $classes();
     $hash = $livewire ? $__livewire->getId().'-'.$property : uniqid();
     $value = $attributes->get('value');
+    $required = $attributes->get('required', false);
 @endphp
 
 @if ($livewire)
@@ -59,6 +60,7 @@
                            '{{ $personalize['input.color.error'] }}': @js($invalidate ?? false) === false && error,
                        }" maxlength="1"
                        autocomplete="false"
+                       @if($required) required @endif
                        x-on:focus="setTimeout(() => $el.selectionStart = $el.selectionEnd = $el.value.length, 0)"
                        x-on:keyup="keyup(@js($index))"
                        x-on:keyup.left="left(@js($index))"

--- a/src/resources/views/components/form/pin.blade.php
+++ b/src/resources/views/components/form/pin.blade.php
@@ -60,7 +60,7 @@
                            '{{ $personalize['input.color.error'] }}': @js($invalidate ?? false) === false && error,
                        }" maxlength="1"
                        autocomplete="false"
-                       @if($required) required @endif
+                       @required($required)
                        x-on:focus="setTimeout(() => $el.selectionStart = $el.selectionEnd = $el.value.length, 0)"
                        x-on:keyup="keyup(@js($index))"
                        x-on:keyup.left="left(@js($index))"


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

Closes #622 

This PR improves the TallStackUi pin component by adding the `required` attribute to each input within the pin set. This change ensures that the browser's built-in validation mechanism is triggered if the user attempts to submit the form without filling out all required pin inputs.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
