### PR TITLE
[1.x] Remove Wrapper of `$slot` in Wrapper Radio

### DIFF
--- a/src/resources/views/components/wrapper/radio.blade.php
+++ b/src/resources/views/components/wrapper/radio.blade.php
@@ -11,9 +11,9 @@
                     {!! $label !!}
                 </span>
                 @endif
-                <div>
-                    {!! $slot !!}
-                </div>
+                
+                {!! $slot !!}
+                
                 @if ($label && $position === 'right')
                 <span @class([$personalize['label.text'], $personalize['label.error'] => $error, 'ml-2'])>
                     {!! $label !!}

--- a/src/resources/views/components/wrapper/radio.blade.php
+++ b/src/resources/views/components/wrapper/radio.blade.php
@@ -11,9 +11,7 @@
                     {!! $label !!}
                 </span>
                 @endif
-                
                 {!! $slot !!}
-                
                 @if ($label && $position === 'right')
                 <span @class([$personalize['label.text'], $personalize['label.error'] => $error, 'ml-2'])>
                     {!! $label !!}


### PR DESCRIPTION
removed slot div wrapper - resolves middle alignment

<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ x ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ x ] I created a new branch on my fork for this pull request 
- [ x ] I ensure that the current tests are passing
- [ no ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [ x ] Bugfix

### Description:

the middle alignment doesn't work with the div wrapper - works better without it.

### Demonstration & Notes:

before:
![image](https://github.com/user-attachments/assets/41d84297-5f5a-45e7-9adf-aaf95369f4ce)

after:
![image](https://github.com/user-attachments/assets/c3be0500-01de-48e7-a50e-fdc96eb5f80c)

