### PR TITLE
[1.x] Dispatching `navigate` Event When Select Different Tabs

### DIFF
--- a/src/resources/views/components/tab/tab.blade.php
+++ b/src/resources/views/components/tab/tab.blade.php
@@ -4,9 +4,9 @@
 
 <div x-data="{ selected: @if (!$selected) {!! TallStackUi::blade($attributes, $livewire)->entangle() !!} @else @js($selected) @endif, tabs: [] }" @class($personalize['base.wrapper'])>
     <div @class($personalize['base.padding'])>
-        <select x-model="selected" @class($personalize['base.select'])>
+        <select x-model="selected" @class($personalize['base.select']) x-on:change="$refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: selected}}));">
             <template x-for="item in tabs">
-                <option x-bind:value="item.tab" x-text="item.tab"></option>
+                <option x-bind:value="item.tab" x-text="item.tab" x-bind:selected="item.tab === selected"></option>
             </template>
         </select>
     </div>


### PR DESCRIPTION
added x-on:change event for select dropdown.
resolved active selected option on select dropdown.

<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x ] I created a new branch on my fork for this pull request 
- [x ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [x ] Enhancements
- [x ] Bugfix

### Description:

added x-on:change to select dropdown.
resolved active option of select dropdown.

### Demonstration & Notes:

No images available.
