### PR TITLE
Allowing Usage of `generator` With Default Password Rules

### DIFF
--- a/src/View/Components/Form/Password.php
+++ b/src/View/Components/Form/Password.php
@@ -25,7 +25,31 @@ class Password extends TallStackUiComponent implements Personalization
         public ?bool $generator = false,
         public ?bool $invalidate = null
     ) {
-        //
+        $default = config('tallstackui.settings.form.password.rules');
+
+        $this->rules = collect(is_bool($this->rules) || is_null($this->rules) ? $default : $this->rules)
+            ->mapWithKeys(function (string $value, ?string $key = null) use ($default): array {
+                // When $this->rules is null, we interact with default values.
+                if (is_null($this->rules)) {
+                    return match ($key) {
+                        'min' => ['min' => $value],
+                        'numbers' => ['numbers' => (bool) $value],
+                        'mixed' => ['mixed' => (bool) $value],
+                        'symbols' => ['symbols' => $value],
+                        default => [],
+                    };
+                }
+
+                $rescued = rescue(fn () => explode(':', $value)[1], report: false);
+
+                return match (true) {
+                    str_contains($value, 'min') => ['min' => $rescued ?? data_get($default, 'min', 8)],
+                    str_contains($value, 'numbers') => ['numbers' => true],
+                    str_contains($value, 'symbols') => ['symbols' => $rescued ?? data_get($default, 'symbols', '!@#$%^&*()_+-=')],
+                    str_contains($value, 'mixed') => ['mixed' => true],
+                    default => [],
+                };
+            });
     }
 
     public function blade(): View
@@ -56,39 +80,6 @@ class Password extends TallStackUiComponent implements Personalization
                 ],
             ],
         ]);
-    }
-
-    protected function setup(): void
-    {
-        if (blank($this->rules) && ! $this->generator) {
-            return;
-        }
-
-        $default = config('tallstackui.settings.form.password.rules');
-
-        $this->rules = collect(is_bool($this->rules) || is_null($this->rules) ? $default : $this->rules)
-            ->mapWithKeys(function (string $value, ?string $key = null) use ($default): array {
-                // When $this->rules is null, we interact with default values.
-                if (is_null($this->rules)) {
-                    return match ($key) {
-                        'min' => ['min' => $value],
-                        'numbers' => ['numbers' => (bool) $value],
-                        'mixed' => ['mixed' => (bool) $value],
-                        'symbols' => ['symbols' => $value],
-                        default => [],
-                    };
-                }
-
-                $rescued = rescue(fn () => explode(':', $value)[1], report: false);
-
-                return match (true) {
-                    str_contains($value, 'min') => ['min' => $rescued ?? data_get($default, 'min', 8)],
-                    str_contains($value, 'numbers') => ['numbers' => true],
-                    str_contains($value, 'symbols') => ['symbols' => $rescued ?? data_get($default, 'symbols', '!@#$%^&*()_+-=')],
-                    str_contains($value, 'mixed') => ['mixed' => true],
-                    default => [],
-                };
-            });
     }
 
     /** @throws Exception */


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

This PR fixes a bug that made it impossible to use `generator` WITHOUT having to specify rules. Now it is possible to use rules from the config file.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
