### PR TITLE
Allowing `select.styled` to be unfiltered by default

### DIFF
--- a/src/Foundation/Support/Configurations/CompileConfigurations.php
+++ b/src/Foundation/Support/Configurations/CompileConfigurations.php
@@ -4,6 +4,7 @@ namespace TallStackUi\Foundation\Support\Configurations;
 
 use Exception;
 use TallStackUi\View\Components\Form\Color;
+use TallStackUi\View\Components\Form\Select\Styled;
 use TallStackUi\View\Components\Interaction\Dialog;
 use TallStackUi\View\Components\Interaction\Toast;
 use TallStackUi\View\Components\Loading;
@@ -26,6 +27,7 @@ class CompileConfigurations
             $component instanceof Dialog => fn () => 'dialog',
             $component instanceof Loading => fn () => $class->loading($component),
             $component instanceof Modal => fn () => $class->modal($component),
+            $component instanceof Styled => fn () => $class->select($component),
             $component instanceof Slide => fn () => $class->slide($component),
             $component instanceof Toast => fn () => 'toast',
             default => fn () => null,
@@ -107,6 +109,17 @@ class CompileConfigurations
 
         return collect($component)
             ->only(['zIndex', 'overflow', 'size', 'blur', 'persistent', 'center'])
+            ->toArray();
+    }
+
+    private function select(Styled $component): array
+    {
+        $configuration = collect(config('tallstackui.settings.form.select.styled'));
+
+        $component->unfiltered ??= $configuration->get('unfiltered', false);
+
+        return collect($component)
+            ->only('unfiltered')
             ->toArray();
     }
 

--- a/src/config.php
+++ b/src/config.php
@@ -210,6 +210,18 @@ return [
                     'symbols' => '!@#$%^&*()_+-=',
                 ],
             ],
+
+            /*
+            |----------------------------------------------------------------------
+            | Select Styled
+            |----------------------------------------------------------------------
+            | unfiltered: allow all select API styled components to be unfiltered by default.
+            */
+            'select' => [
+                'styled' => [
+                    'unfiltered' => false,
+                ],
+            ],
         ],
 
         /*

--- a/src/resources/views/components/select/styled.blade.php
+++ b/src/resources/views/components/select/styled.blade.php
@@ -20,7 +20,7 @@
         @js($value),
         @js($limit),
         @js($change),
-        @js($unfiltered),
+        @js($configurations['unfiltered']),
         @js($lazy))"
         x-cloak
         x-on:keydown="navigate($event)"


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

This PR adds the possibility to make all `select.styled` components in use `unfiltered` by default via a dedicated key in the config file.

### Demonstration & Notes:

New content to the config file 👇🏻 

```php
/*
|----------------------------------------------------------------------
| Select Styled
|----------------------------------------------------------------------
| unfiltered: allow all select API styled components to be unfiltered by default.
*/
'select' => [
    'styled' => [
        'unfiltered' => false,
    ],
],
```
