### PR TITLE
Allow `label` to Render Raw HTML

### DIFF
--- a/src/resources/views/components/form/label.blade.php
+++ b/src/resources/views/components/form/label.blade.php
@@ -3,7 +3,7 @@
 @endphp
 
 <label @if ($id) for="{{ $id }}" @endif @class([$personalize['text'], $personalize['error'] => $error && !$invalidate])>
-    {{ $word }}
+    {!! $word !!}
     @if ($asterisk)
         <span class="{{ $personalize['asterisk'] }}">*</span>
     @endif


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

This allows using the label slot with html content on components like input

### Demonstration & Notes:

```
 <x-input wire:model="someValue">
    <x-slot:label>
        <span x-bind:text="editMode ? 'Enter something…' : 'Read only…'"></span>
    </x-slot:label>
</x-input>

```