### PR TITLE
Add Support to `x-bind:src` in Avatar Component

### DIFF
--- a/src/resources/views/components/avatar.blade.php
+++ b/src/resources/views/components/avatar.blade.php
@@ -8,13 +8,13 @@
         $personalize['wrapper.class'],
         $colors['background'] => !$model,
         $personalize['wrapper.sizes.' . $size],
-    ]) }}>
+    ])->except('x-bind:src') }}>
     @if ($model || $image)
         <img @class([
             $personalize['border.radius'] => !$square,
             $personalize['content.image.class'],
             $personalize['content.image.sizes.' . $size],
-        ]) src="{{ $image ?? $modelable() }}" alt="{{ $text ?? $model?->getAttribute($property ?? null) }}"/>
+        ]) {{ $attributes->only('x-bind:src') }} src="{{ $image ?? $modelable() }}" alt="{{ $text ?? $model?->getAttribute($property ?? null) }}"/>
     @elseif ($text || $slot->isNotEmpty())
         <span @class([
                 $personalize['content.text.class'],

--- a/tests/Browser/Avatar/IndexTest.php
+++ b/tests/Browser/Avatar/IndexTest.php
@@ -20,17 +20,10 @@ class IndexTest extends BrowserTestCase
                 <div x-data="{image: 'https://cdn.dribbble.com/users/17793/screenshots/16101765/media/beca221aaebf1d3ea7684ce067bc16e5.png'}">
                     <x-avatar image x-bind:src="image" />
                 </div>
-            HTML;
+                HTML;
             }
         })
             ->waitFor('img[src="https://cdn.dribbble.com/users/17793/screenshots/16101765/media/beca221aaebf1d3ea7684ce067bc16e5.png"]')
             ->assertVisible('img[src="https://cdn.dribbble.com/users/17793/screenshots/16101765/media/beca221aaebf1d3ea7684ce067bc16e5.png"]');
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->skipOnGitHubActions('This test is not compatible with GitHub Actions');
     }
 }

--- a/tests/Browser/Avatar/IndexTest.php
+++ b/tests/Browser/Avatar/IndexTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Browser\Avatar;
+
+use Livewire\Component;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Browser\BrowserTestCase;
+
+class IndexTest extends BrowserTestCase
+{
+    #[Test]
+    public function can_bind_src(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div x-data="{image: 'https://cdn.dribbble.com/users/17793/screenshots/16101765/media/beca221aaebf1d3ea7684ce067bc16e5.png'}">
+                    <x-avatar image x-bind:src="image" />
+                </div>
+            HTML;
+            }
+        })
+            ->waitFor('img[src="https://cdn.dribbble.com/users/17793/screenshots/16101765/media/beca221aaebf1d3ea7684ce067bc16e5.png"]')
+            ->assertVisible('img[src="https://cdn.dribbble.com/users/17793/screenshots/16101765/media/beca221aaebf1d3ea7684ce067bc16e5.png"]');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipOnGitHubActions('This test is not compatible with GitHub Actions');
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

Allows binding of avatar using alpine. This could enable using the avatar component in toasts later on…

### Demonstration & Notes:

see new test, easy example
