### PR TITLE
Allow Modal `full` Width Size

### DIFF
--- a/src/Foundation/Support/Configurations/CompileConfigurations.php
+++ b/src/Foundation/Support/Configurations/CompileConfigurations.php
@@ -104,6 +104,7 @@ class CompileConfigurations
             '5xl' => 'sm:max-w-5xl',
             '6xl' => 'sm:max-w-6xl',
             '7xl' => 'sm:max-w-7xl',
+            'full' => 'max-w-full',
             default => 'sm:max-w-2xl',
         };
 

--- a/src/View/Components/Modal.php
+++ b/src/View/Components/Modal.php
@@ -73,7 +73,7 @@ class Modal extends TallStackUiComponent implements Personalization
         }
 
         $configuration = collect(config('tallstackui.settings.modal'));
-        $sizes = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl'];
+        $sizes = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl', 'full'];
 
         if (! in_array($this->size ?? $configuration->get('size', '2xl'), $sizes)) {
             throw new InvalidArgumentException('The modal size must be one of the following: ['.implode(', ', $sizes).']');

--- a/tests/Feature/Components/Modal/IndexTest.php
+++ b/tests/Feature/Components/Modal/IndexTest.php
@@ -33,7 +33,7 @@ it('can thrown exception when wire is empty', function () {
 
 it('can thrown exception when size is unnaceptable', function (string $size) {
     $this->expectException(ViewException::class);
-    $this->expectExceptionMessage('The modal size must be one of the following: [sm, md, lg, xl, 2xl, 3xl, 4xl, 5xl, 6xl, 7xl]');
+    $this->expectExceptionMessage('The modal size must be one of the following: [sm, md, lg, xl, 2xl, 3xl, 4xl, 5xl, 6xl, 7xl, full]');
 
     $component = <<<'HTML'
     <x-modal size="{{ size }}">


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

This adds the size "full" to the sizes allowing modals to open in full width

### Demonstration & Notes:

Should be pretty clear ;)
