### PR TITLE
Fixing Component Instance Duplication

### DIFF
--- a/src/Foundation/Personalization/PersonalizationFactory.php
+++ b/src/Foundation/Personalization/PersonalizationFactory.php
@@ -2,6 +2,7 @@
 
 namespace TallStackUi\Foundation\Personalization;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\View as Facade;
@@ -14,7 +15,7 @@ use RuntimeException;
  *
  * @property-read Personalization $and
  */
-class PersonalizationFactory
+class PersonalizationFactory implements Arrayable
 {
     /**
      * Block name to be personalized.
@@ -22,9 +23,14 @@ class PersonalizationFactory
     public ?string $block = null;
 
     /**
+     * Blocks available for personalization.
+     */
+    public array $blocks = [];
+
+    /**
      * Original classes of the component with changes applied.
      */
-    private readonly Collection $changes;
+    private Collection $changes;
 
     /**
      * Interactions, for when we are personalizing without $code for the block.
@@ -39,7 +45,6 @@ class PersonalizationFactory
     public function __construct(public readonly string $component, private readonly ?string $scope = null)
     {
         $this->interactions = $this->parts = collect();
-        $this->changes = collect(app($this->component)->personalization());
     }
 
     /**
@@ -83,6 +88,13 @@ class PersonalizationFactory
      */
     public function block(string|array $name, string|callable|null $code = null): self
     {
+        // The idea of this code existing in the file and not in the construct
+        // is to avoid an unnecessary call every time the component is rendered,
+        // even if it has no customizations to be applied.
+        $personalization = app($this->component)->personalization();
+        $this->changes = collect($personalization);
+        $this->blocks = array_keys($personalization);
+
         // If the $code was not set, then we
         // are interacting with the shortcuts.
         if (is_string($name) && is_null($code)) {
@@ -149,20 +161,10 @@ class PersonalizationFactory
         return $this;
     }
 
-    /**
-     * Get the parts as array.
-     */
+    /** {@inheritDoc} */
     public function toArray(): array
     {
         return $this->parts->toArray();
-    }
-
-    /**
-     * Get all the blocks available for personalization in the component.
-     */
-    private function blocks(): array
-    {
-        return array_keys(app($this->component)->personalization());
     }
 
     /**
@@ -211,10 +213,10 @@ class PersonalizationFactory
     {
         $view = app($this->component)->blade()->name();
 
-        if (! in_array($block, $blocks = $this->blocks())) {
+        if (! in_array($block, $this->blocks)) {
             $component = str_replace('tallstack-ui::components.', '', (string) $view);
 
-            throw new InvalidArgumentException("Component [$component] does not have the block [$block] to be personalized. Allowed: ".implode(', ', $blocks));
+            throw new InvalidArgumentException("Component [$component] does not have the block [$block] to be personalized. Allowed: ".implode(', ', $this->blocks));
         }
 
         // We leave everything prepared and linked with the


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

I just discovered that rendering all components that use Soft Personalization created a duplicate instance of the component. Outputting something like `dump(1);` in the component construct generated two records instead of just one. After much investigation, I realized that the problem is associated with the call to `app($this->component)` in `PersonalizationFactory::__construct`. As a solution, this logic was moved to `block` which still makes sense since all personalization should pass through `block` method, and fixes this duplication of instances. With that, we ensure we will only create a new instance when we are really personalizing the components.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif or video), and also
add any notes that you think are important.  -->
