### PR TITLE
Allow usage of x-model on `select.styled`

### DIFF
--- a/src/Foundation/Support/Blade/Wireable.php
+++ b/src/Foundation/Support/Blade/Wireable.php
@@ -34,8 +34,8 @@ class Wireable
         $property = $wire->value();
 
         return $wire->hasModifier('live') || $wire->hasModifier('blur')
-            ? Blade::render("@entangle('{$property}').live")
-            : Blade::render("@entangle('{$property}')");
+            ? Blade::render("\$wire.entangle('{$property}').live")
+            : Blade::render("\$wire.entangle('{$property}')");
     }
 
     // This is a helper function commonly used in Blade

--- a/src/resources/views/components/select/styled.blade.php
+++ b/src/resources/views/components/select/styled.blade.php
@@ -23,8 +23,8 @@
         @js($configurations['unfiltered']),
         @js($lazy))"
         @if ($attributes->whereStartsWith('x-model'))
-        x-modelable="model"
-        {{ $attributes->whereStartsWith('x-model') }}
+            x-modelable="model"
+            {{ $attributes->whereStartsWith('x-model') }}
         @endif
         x-cloak
         x-on:keydown="navigate($event)"

--- a/src/resources/views/components/select/styled.blade.php
+++ b/src/resources/views/components/select/styled.blade.php
@@ -22,7 +22,7 @@
         @js($change),
         @js($configurations['unfiltered']),
         @js($lazy))"
-        @if($attributes->whereStartsWith('x-model'))
+        @if ($attributes->whereStartsWith('x-model'))
         x-modelable="model"
         {{ $attributes->whereStartsWith('x-model') }}
         @endif

--- a/src/resources/views/components/select/styled.blade.php
+++ b/src/resources/views/components/select/styled.blade.php
@@ -22,6 +22,10 @@
         @js($change),
         @js($configurations['unfiltered']),
         @js($lazy))"
+        @if($attributes->whereStartsWith('x-model'))
+        x-modelable="model"
+        {{ $attributes->whereStartsWith('x-model') }}
+        @endif
         x-cloak
         x-on:keydown="navigate($event)"
         wire:ignore.self>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

This PR allows the usage of x-model on select component.
Im some cases its useful to loop through an array which results in proxy objects to a nested livewire array. In these cases wire:model is hard to use, its easier to bind to the loop object.

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

<!-- Describe your PR, which more details as possible. -->

### Demonstration & Notes:

```
<template x-for="item in $wire.arrayProp">
    <x-select.styled
        x-model.number="item.id"
        select="label:name|value:id"
        :options="Items::all()->toArray()"
    />
</template>
```