### PR TITLE
Pin Component: Numeric Keyboard on Mobile When Numbers Option is Enabled

### DIFF
--- a/src/resources/views/components/form/pin.blade.php
+++ b/src/resources/views/components/form/pin.blade.php
@@ -56,6 +56,9 @@
                            '{{ $personalize['input.color.error'] }}': @js($invalidate ?? false) === false && error,
                        }" maxlength="1"
                        autocomplete="false"
+                       @if ($numbers)
+                          inputmode="numeric"
+                       @endif
                        @required($attributes->get('required', false))
                        x-on:focus="setTimeout(() => $el.selectionStart = $el.selectionEnd = $el.value.length, 0)"
                        x-on:keyup="keyup(@js($index))"


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:
Added inputmode="numeric" to the Pin component when the numbers option is enabled, ensuring better compatibility and user experience for numeric input fields.
<!-- Describe your PR, which more details as possible. -->

### Demonstration & Notes:
Currently, when the numbers option is enabled, the Pin component opens the default keyboard on mobile devices. With this PR, the inputmode="numeric" attribute is added, ensuring that only the numeric keyboard is displayed on mobile devices
<!-- Insert a demonstration about the changes or 
the features (image, gif, or video), and also
add any notes that you think are important.  -->
