### PR TITLE
Handle complex `dropdown` items with a div instead of a button

### DIFF
--- a/src/Foundation/Support/Runtime/Components/DropdownItemsRuntime.php
+++ b/src/Foundation/Support/Runtime/Components/DropdownItemsRuntime.php
@@ -8,10 +8,6 @@ class DropdownItemsRuntime extends AbstractRuntime
 {
     public function runtime(): array
     {
-        return ['tag' => filled($this->data('href')) 
-            ? 'a' 
-            : ($this->data('text') 
-                ? 'button' 
-                : 'div')];
+        return ['tag' => filled($this->data('href')) ? 'a' : ($this->data('text') ? 'button' : 'div')];
     }
 }

--- a/src/Foundation/Support/Runtime/Components/DropdownItemsRuntime.php
+++ b/src/Foundation/Support/Runtime/Components/DropdownItemsRuntime.php
@@ -8,6 +8,10 @@ class DropdownItemsRuntime extends AbstractRuntime
 {
     public function runtime(): array
     {
-        return ['tag' => filled($this->data('href')) ? 'a' : 'button'];
+        return ['tag' => filled($this->data('href')) 
+            ? 'a' 
+            : ($this->data('text') 
+                ? 'button' 
+                : 'div')];
     }
 }


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

In some cases, dropdown elements can be more complex than just a simple text (using the `text="Simple use case"` attribute, which renders a button with the given text).

For more complex cases, the component's slot is used to render a custom template (which, by the way, is not documented). However, the rendered content is not supposed to be inside a button, as this can cause appearance issues.

This PR proposes wrapping everything that is neither a link nor has a `text` attribute inside a `<div>`.

### Demonstration & Notes:

Try to use a `<x-color>` component in a dropdown item for example, this will break the x-color component and other stuff in the page.
