### PR TITLE
Introducing `visible` Attribute to `side-bar.item` Component

### DIFF
--- a/src/View/Components/Layout/SideBar/Item.php
+++ b/src/View/Components/Layout/SideBar/Item.php
@@ -2,6 +2,7 @@
 
 namespace TallStackUi\View\Components\Layout\SideBar;
 
+use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
@@ -20,8 +21,9 @@ class Item extends TallStackUiComponent implements Personalization
         public ComponentSlot|string|null $icon = null,
         public ?bool $current = null,
         public ?bool $opened = null,
+        public Closure|bool $visible = true,
     ) {
-        //
+        $this->visible = value($this->visible);
     }
 
     public function blade(): View
@@ -58,7 +60,7 @@ class Item extends TallStackUiComponent implements Personalization
     {
         return Arr::dot([
             'group' => [
-                'button' => 'text-primary-500 hover:bg-primary-50/50 dark:hover:bg-dark-600/50 flex w-full items-center gap-x-3 rounded-md p-2 text-left text-sm font-semibold transition-all dark:text-white',
+                'button' => 'text-primary-500 hover:bg-primary-50/50 dark:hover:bg-dark-600/50 flex w-full items-center gap-x-3 rounded-md p-2 text-left text-sm font-semibold transition-all dark:text-white cursor-pointer',
                 'icon' => [
                     'base' => 'text-primary-500 h-6 w-6 shrink-0 dark:text-white',
                     'collapse' => [

--- a/src/resources/views/components/layout/sidebar/item.blade.php
+++ b/src/resources/views/components/layout/sidebar/item.blade.php
@@ -4,48 +4,50 @@
 
 @aware(['smart' => null, 'navigate' => null, 'navigateHover' => null])
 
-@if ($slot->isNotEmpty())
-    <li x-data="{ show : @js($opened ?? \Illuminate\Support\Str::contains($slot, 'ts-ui-group-opened') ?? false) }">
-        <button x-on:click="show = !show"
-                type="button"
-                class="{{ $personalize['group.button'] }}">
-            @if ($icon instanceof \Illuminate\View\ComponentSlot)
-                {{ $icon }}
-            @elseif ($icon)
+@if ($visible)
+    @if ($slot->isNotEmpty())
+        <li x-data="{ show : @js($opened ?? \Illuminate\Support\Str::contains($slot, 'ts-ui-group-opened') ?? false) }">
+            <button x-on:click="show = !show"
+                    type="button"
+                    class="{{ $personalize['group.button'] }}">
+                @if ($icon instanceof \Illuminate\View\ComponentSlot)
+                    {{ $icon }}
+                @elseif ($icon)
+                    <x-dynamic-component :component="TallStackUi::prefix('icon')"
+                                         :icon="TallStackUi::icon($icon)"
+                                         internal
+                                         class="{{ $personalize['group.icon.base'] }}" />
+                @endif
+                {{ $text }}
                 <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                                     :icon="TallStackUi::icon($icon)"
+                                     :icon="TallStackUi::icon('chevron-down')"
                                      internal
-                                     class="{{ $personalize['group.icon.base'] }}" />
-            @endif
-            {{ $text }}
-            <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                                 :icon="TallStackUi::icon('chevron-down')"
-                                 internal
-                                 class="{{ $personalize['group.icon.collapse.base'] }}"
-                                 x-bind:class="{ '{{ $personalize['group.icon.collapse.rotate'] }}': show }" />
-        </button>
-        <ul x-show="show" class="{{ $personalize['group.group'] }}" x-data x-ref="parent">
-            {{ $slot }}
-        </ul>
-    </li>
-@else
-    <li class="{{ $personalize['item.wrapper.base'] }}"
-        x-bind:class="{ '{{ $personalize['item.wrapper.border'] }}' : $refs.parent !== undefined }">
-        <a @if ($route) href="{{ $route }}" @endif
+                                     class="{{ $personalize['group.icon.collapse.base'] }}"
+                                     x-bind:class="{ '{{ $personalize['group.icon.collapse.rotate'] }}': show }" />
+            </button>
+            <ul x-show="show" class="{{ $personalize['group.group'] }}" x-data x-ref="parent">
+                {{ $slot }}
+            </ul>
+        </li>
+    @else
+        <li class="{{ $personalize['item.wrapper.base'] }}"
+            x-bind:class="{ '{{ $personalize['item.wrapper.border'] }}' : $refs.parent !== undefined }">
+            <a @if ($route) href="{{ $route }}" @endif
             @class([
                 $personalize['item.state.base'],
                 $personalize['item.state.normal'] => ! $current || (! $smart && ! $matches()),
                 \Illuminate\Support\Arr::toCssClasses(['ts-ui-group-opened', $personalize['item.state.current']]) => $current || ($smart && $matches()),
             ]) @if ($navigate) wire:navigate @elseif ($navigateHover) wire:navigate.hover @endif>
-            @if ($icon instanceof \Illuminate\View\ComponentSlot)
-                {{ $icon }}
-            @elseif ($icon)
-                <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                                     :icon="TallStackUi::icon($icon)"
-                                     internal
-                                     class="{{ $personalize['item.icon'] }}" />
-            @endif
-            {{ $text }}
-        </a>
-    </li>
+                @if ($icon instanceof \Illuminate\View\ComponentSlot)
+                    {{ $icon }}
+                @elseif ($icon)
+                    <x-dynamic-component :component="TallStackUi::prefix('icon')"
+                                         :icon="TallStackUi::icon($icon)"
+                                         internal
+                                         class="{{ $personalize['item.icon'] }}" />
+                @endif
+                {{ $text }}
+            </a>
+        </li>
+    @endif
 @endif


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

This PR aims to introduce a `visible` attribute that can control status of the `side-bar.item`.

### Demonstration & Notes:

Resolving as a boolean:

```blade
<x-side-bar.item text="Home" icon="cog" :visible="false">
    <x-side-bar.item text="Home" icon="home" :route="route('livewire')" />
    <x-side-bar.item text="Settings" icon="cog" :route="route('manual.index')" />
</x-side-bar.item>
```

Resolving as a closure:

```blade
<x-side-bar.item text="Home" icon="cog" :visible="fn () => false">
    <x-side-bar.item text="Home" icon="home" :route="route('livewire')" />
    <x-side-bar.item text="Settings" icon="cog" :route="route('manual.index')" />
</x-side-bar.item>
```