### PR TITLE
Allowing `stats` Component Accepts Raw HTML in Icon Slot

### DIFF
--- a/src/View/Components/Stats.php
+++ b/src/View/Components/Stats.php
@@ -22,7 +22,7 @@ class Stats extends TallStackUiComponent implements Personalization
     public function __construct(
         public string|int|null $number = null,
         public ?string $title = null,
-        public ?string $icon = null,
+        public ComponentSlot|string|null $icon = null,
         public ?string $color = 'primary',
         public ?string $href = null,
         public ?bool $solid = true,

--- a/src/resources/views/components/stats.blade.php
+++ b/src/resources/views/components/stats.blade.php
@@ -27,12 +27,18 @@
             $personalize['wrapper.second'],
         ])>
         @if ($icon)
-            <div @class([$personalize['wrapper.third'], $colors['background']])>
-                <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                                     :$icon
-                                     internal
-                                     class="{{ $personalize['icon'] }}" />
-            </div>
+            @if (!$icon instanceof \Illuminate\View\ComponentSlot)
+                <div @class([$personalize['wrapper.third'], $colors['background']])>
+                    <x-dynamic-component :component="TallStackUi::prefix('icon')"
+                                         :$icon
+                                         internal
+                                         class="{{ $personalize['icon'] }}" />
+                </div>
+            @else
+                <div class="{{ $personalize['wrapper.third'] }}">
+                    {{ $icon }}
+                </div>
+            @endif
         @endif
         <div class="grow">
             @if ($title) <h2 class="{{ $personalize['title'] }}">{{ $title }}</h2> @endif


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

This PR aims to transform the `icon` of the `stats` in both string-based icon and also raw HTML content as a component slot.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif, or video), and also
add any notes that you think are important.  -->
