### PR TITLE
[2.x] Added `submit` Attribute to Button and Circle Components

### DIFF
--- a/src/View/Components/Button/Button.php
+++ b/src/View/Components/Button/Button.php
@@ -39,6 +39,7 @@ class Button extends TallStackUiComponent implements Personalization
         public ?bool $outline = false,
         public ?bool $light = false,
         public ?bool $flat = false,
+        public ?bool $submit = false,
         #[SkipDebug]
         public ?string $size = null,
         #[SkipDebug]

--- a/src/View/Components/Button/Circle.php
+++ b/src/View/Components/Button/Circle.php
@@ -36,6 +36,7 @@ class Circle extends TallStackUiComponent implements Personalization
         public ?bool $outline = null,
         public ?bool $light = false,
         public ?bool $flat = false,
+        public ?bool $submit = false,
         #[SkipDebug]
         public ?string $size = null,
         #[SkipDebug]

--- a/src/resources/views/components/button/button.blade.php
+++ b/src/resources/views/components/button/button.blade.php
@@ -8,7 +8,7 @@
         $colors['background'],
         $personalize['wrapper.border.radius.rounded'] => !$square && !$round,
         $personalize['wrapper.border.radius.circle'] => !$square && $round !== null,
-    ]) }} type="{{ $attributes->get('type', 'button') }}" @if ($livewire && $loading) wire:loading.attr="disabled" wire:loading.class="!cursor-wait" @endif>
+    ]) }} type="{{ $attributes->get('type', $submit ? 'submit' : 'button') }}" @if ($livewire && $loading) wire:loading.attr="disabled" wire:loading.class="!cursor-wait" @endif>
     @if ($livewire && $loading && $position === 'left')
         <x-tallstack-ui::icon.generic.loading-button :$loading :$delay @class([
                 'animate-spin',

--- a/src/resources/views/components/button/circle.blade.php
+++ b/src/resources/views/components/button/circle.blade.php
@@ -6,7 +6,7 @@
         $personalize['wrapper.base'],
         $personalize['wrapper.sizes.' . $size],
         $colors['background']
-    ]) }} type="{{ $attributes->get('type', 'button') }}" @if ($livewire && $loading) wire:loading.attr="disabled" wire:loading.class="!cursor-wait" @endif>
+    ]) }} type="{{ $attributes->get('type', $submit ? 'submit' : 'button') }}" @if ($livewire && $loading) wire:loading.attr="disabled" wire:loading.class="!cursor-wait" @endif>
 @if ($icon)
     <x-dynamic-component :component="TallStackUi::prefix('icon')"
                          :$icon

--- a/tests/Feature/Components/Button/ButtonTest.php
+++ b/tests/Feature/Components/Button/ButtonTest.php
@@ -50,6 +50,11 @@ it('can render with icon')
     ->render()
     ->toContain('<svg');
 
+it('can render with type submit')
+    ->expect('<x-button text="Foo bar" submit />')
+    ->render()
+    ->toContain('type="submit"', false);
+
 it('can render colored', function (string $colors) {
     $component = <<<HTML
     <x-button text="Foo bar" color="$colors" />

--- a/tests/Feature/Components/Button/CircleTest.php
+++ b/tests/Feature/Components/Button/CircleTest.php
@@ -80,3 +80,8 @@ it('can render xs', function () {
         ->toContain('w-4 h-4')
         ->toContain('w-2 h-2');
 });
+
+it('can render with type submit')
+    ->expect('<x-button.circle icon="pencil" submit />')
+    ->render()
+    ->toContain('type="submit"', false);


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

Creating a basic "alias" called `submit` to do not need to write `type="submit"` in the buttons.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif, or video), and also
add any notes that you think are important.  -->
