### PR TITLE
Transforming the `KeyValue` inputs to `readonly` when `static` is set

### DIFF
--- a/src/resources/views/components/key-value.blade.php
+++ b/src/resources/views/components/key-value.blade.php
@@ -26,6 +26,7 @@
                            x-on:keyup.shift.enter="add"
                            x-on:keyup.enter="sync"
                            dusk="tallstackui_input_key"
+                           @readonly($static)
                            @if ($placeholders) placeholder="{{ trans('tallstack-ui::messages.key-value.placeholders.key') }}"
                            @endif
                            class="{{ $personalize['list.input.key'] }}"/>
@@ -41,6 +42,7 @@
                                dusk="tallstackui_input_value"
                                @if ($placeholders) placeholder="{{ trans('tallstack-ui::messages.key-value.placeholders.value') }}"
                                @endif
+                               @readonly($static)
                                class="{{ $personalize['list.input.value'] }}"/>
                     </div>
                     @if ($deletable)

--- a/tests/Browser/KeyValue/IndexTest.php
+++ b/tests/Browser/KeyValue/IndexTest.php
@@ -206,6 +206,37 @@ class IndexTest extends BrowserTestCase
     }
 
     #[Test]
+    public function cannot_interact_with_input_when_static()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public array $metadata = [
+                [
+                    'key' => 'blabla',
+                    'value' => 'xoxo',
+                ],
+                [
+                    'key' => 'blabla',
+                    'value' => 'xoxo',
+                ],
+            ];
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                    <div>
+                        <x-key-value wire:model="metadata" static />
+                    </div>
+                HTML;
+            }
+        })
+            ->assertSee('KEY')
+            ->assertSee('VALUE')
+            ->assertAttribute('@tallstackui_input_key', 'readonly', true)
+            ->assertAttribute('@tallstackui_input_value', 'readonly', true);
+    }
+
+    #[Test]
     public function cannot_see_add_button_when_already_set_and_in_limit()
     {
         Livewire::visit(new class extends Component


### PR DESCRIPTION
…mplementation

<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

Transforming the inputs to `readonly` when `static` is set.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif, or video), and also
add any notes that you think are important.  -->
