### PR TITLE
[2.x] Added Support to `href` and Attributes to `SideBar/Item` Component

### DIFF
--- a/src/View/Components/Layout/SideBar/Item.php
+++ b/src/View/Components/Layout/SideBar/Item.php
@@ -17,6 +17,7 @@ class Item extends TallStackUiComponent implements Personalization
     public function __construct(
         public ?string $text = null,
         public ?string $route = null,
+        public ?string $href = null,
         public ?string $match = null,
         public ComponentSlot|string|null $icon = null,
         public ?bool $current = null,

--- a/src/resources/views/components/layout/sidebar/item.blade.php
+++ b/src/resources/views/components/layout/sidebar/item.blade.php
@@ -35,12 +35,18 @@
         </li>
     @else
         <li class="{{ $personalize['item.wrapper.base'] }}" x-bind:class="{ '{{ $personalize['item.wrapper.border'] }}' : $refs.parent !== undefined }">
-            <a @if ($route) href="{{ $route }}" @endif
+            <a @if ($route || $href) href="{{ $route ?? $href }}" @endif
             @class([
                 $personalize['item.state.base'],
                 $personalize['item.state.normal'] => ! $current || (! $smart && ! $matches()),
                 \Illuminate\Support\Arr::toCssClasses(['ts-ui-group-opened', $personalize['item.state.current']]) => $current || ($smart && $matches()),
-            ]) x-bind:class="{'{{ $personalize['item.state.collapsed'] }}' : @js($collapsible) && ! $store['tsui.side-bar'].open && ! $store['tsui.side-bar'].mobile }" @if ($navigate) wire:navigate @elseif ($navigateHover) wire:navigate.hover @endif>
+            ]) x-bind:class="{'{{ $personalize['item.state.collapsed'] }}' : @js($collapsible) && ! $store['tsui.side-bar'].open && ! $store['tsui.side-bar'].mobile }"
+                @if ($navigate && ! $href)
+                    wire:navigate
+                @elseif ($navigateHover && ! $href)
+                   wire:navigate.hover
+                @endif
+                {{ $attributes }}>
                 @if ($icon instanceof \Illuminate\View\ComponentSlot)
                     {{ $icon }}
                 @elseif ($icon)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

Relates to https://github.com/tallstackui/tallstackui/issues/847

---

The `side-bar.item` now supports `href` and things like `target` 👇🏻 

### Demonstration & Notes:


```blade
<x-slot:menu>
    <x-side-bar smart navigate collapsible>
        <x-side-bar.item text="Welcome" icon="home" href="https://google.com.br" target="_blank" />
    </x-side-bar>
</x-slot:menu>
```
