### PR TITLE
[2.x] fix opacity loading component

### DIFF
--- a/src/View/Components/Loading.php
+++ b/src/View/Components/Loading.php
@@ -38,7 +38,7 @@ class Loading extends TallStackUiComponent implements Personalization
                 'first' => 'fixed inset-0 bg-gray-300 dark:bg-dark-600',
                 'second' => 'flex h-full items-center justify-center',
             ],
-            'opacity' => 'opacity-75 dark:opacity-70',
+            'opacity' => 'bg-gray-300/75 dark:bg-dark-600/70',
             'blur' => 'backdrop-blur-sm',
             'spinner' => 'h-12 w-12 animate-spin text-primary-700 dark:text-white',
             'text' => 'inline-flex items-center text-lg font-semibold text-primary-500',


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

I detected a problem with the loading opacity, I should really give opacity to the background color and not to the element in general, additionally when the opacity is 'true' and the blur is the same, they do not work together, it is a small fix that improves the user experience more than the developer.

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif, or video), and also
add any notes that you think are important.  -->
![image](https://github.com/user-attachments/assets/649f6fdd-de80-4efb-b646-711d7997b157)
![image](https://github.com/user-attachments/assets/99e75309-21df-4f24-a48a-bc27f4150f89)

