### PR TITLE
[2.x] Truncate Sidebar `separator` Text when SideBar is closed

### DIFF
--- a/src/resources/views/components/layout/sidebar/separator.blade.php
+++ b/src/resources/views/components/layout/sidebar/separator.blade.php
@@ -4,24 +4,24 @@
 
 @if ($simple)
     <div class="{{ $personalize['simple.wrapper'] }}">
-        <span class="{{ $personalize['simple.base'] }}">{{ $text ?? $slot }}</span>
+        <span class="{{ $personalize['simple.base'] }}" x-text="$store['tsui.side-bar'].open ? @js($text ?? $slot) : @js(str($text ?? $slot)->limit(5))"></span>
     </div>
 @elseif ($line)
     <div class="{{ $personalize['line.wrapper.first'] }}">
-        <div class="{{ $personalize['line.wrapper.second'] }}">
+        <div class="{{ $personalize['line.wrapper.second'] }}" x-show="$store['tsui.side-bar'].open">
             <div class="{{ $personalize['line.border'] }}"></div>
         </div>
         <div class="{{ $personalize['line.wrapper.third'] }}">
-            <span class="{{ $personalize['line.base'] }}">{{ $text ?? $slot }}</span>
+            <span class="{{ $personalize['line.base'] }}" x-text="$store['tsui.side-bar'].open ? @js($text ?? $slot) : @js(str($text ?? $slot)->limit(5))"></span>
         </div>
     </div>
 @else
     <div class="{{ $personalize['line-right.wrapper.first'] }}">
-        <div class="{{ $personalize['line-right.wrapper.second'] }}">
+        <div class="{{ $personalize['line-right.wrapper.second'] }}" x-show="$store['tsui.side-bar'].open">
             <div class="{{ $personalize['line-right.border'] }}"></div>
         </div>
         <div class="{{ $personalize['line-right.wrapper.third'] }}">
-            <span class="{{ $personalize['line-right.base'] }}">{{ $text ?? $slot }}</span>
+            <span class="{{ $personalize['line-right.base'] }}" x-text="$store['tsui.side-bar'].open ? @js($text ?? $slot) : @js(str($text ?? $slot)->limit(5))"></span>
         </div>
     </div>
 @endif


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

Relates to #1021 

### Demonstration & Notes:

![CleanShot 2025-06-23 at 00 46 41](https://github.com/user-attachments/assets/ddfa74bf-97e3-4bd2-9f41-c1d821a83d06)

