### PR TITLE
fix(DateRuntime): handle null dates in range validation

### DIFF
--- a/src/Foundation/Support/Runtime/Components/DateRuntime.php
+++ b/src/Foundation/Support/Runtime/Components/DateRuntime.php
@@ -40,15 +40,19 @@ class DateRuntime extends AbstractRuntime
             return;
         }
 
-        if (($range || $multiple) && ! is_array($value)) {
+        if (($range || $multiple) && !is_array($value)) {
             __ts_validation_exception($this->component, 'The [value] must be an array when using the [range] or [multiple].');
         }
 
         if ($range && count($value) === 2) {
-            [$start, $end] = array_map(fn (?string $date) => Carbon::parse($date), $value);
+            [$start, $end] = array_map(function (?string $date) {
+                return $date !== null ? Carbon::parse($date) : null;
+            }, $value);
 
-            if ($start->greaterThan($end)) {
-                __ts_validation_exception($this->component, 'The start date in the [range] must be greater than the second date.');
+            if ($start instanceof Carbon && $end instanceof Carbon) {
+                if ($start->greaterThan($end)) {
+                    __ts_validation_exception($this->component, 'The start date in the [range] must be greater than the second date.');
+                }
             }
         }
     }

--- a/src/Foundation/Support/Runtime/Components/DateRuntime.php
+++ b/src/Foundation/Support/Runtime/Components/DateRuntime.php
@@ -40,7 +40,7 @@ class DateRuntime extends AbstractRuntime
             return;
         }
 
-        if (($range || $multiple) && !is_array($value)) {
+        if (($range || $multiple) && ! is_array($value)) {
             __ts_validation_exception($this->component, 'The [value] must be an array when using the [range] or [multiple].');
         }
 


### PR DESCRIPTION
Check for null values before parsing dates in range validation to prevent errors when dates are null

<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

<!-- Describe your PR, which more details as possible. -->
I found an error when using Date range and I chose the start date as the 5th but now it is the 2nd then I will find this error :
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/26523d39-6b24-42bb-91f1-54d2b2fc1c7c" />

i found error in this code :
<img width="949" alt="image" src="https://github.com/user-attachments/assets/22d437dc-e73b-416d-8d72-8eae6412ddfa" />


If I enter a start date then by default $end is the current date, it will cause an error even though I just entered start

if i input for start date


### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif, or video), and also
add any notes that you think are important.  -->
