### PR TITLE
[2.x] Allowing `card` to use RAW HTML in `header` and `footer`

### DIFF
--- a/src/View/Components/Card.php
+++ b/src/View/Components/Card.php
@@ -57,8 +57,8 @@ class Card extends TallStackUiComponent implements Personalization
             ],
             'header' => [
                 'wrapper' => [
-                    'base' => 'dark:border-b-dark-600 flex items-center justify-between p-4',
-                    'border' => 'border-b border-gray-100',
+                    'base' => 'flex items-center justify-between p-4',
+                    'border' => 'dark:border-b-dark-600 border-b border-gray-100',
                 ],
                 'text' => [
                     'size' => 'text-md font-medium',
@@ -67,7 +67,7 @@ class Card extends TallStackUiComponent implements Personalization
             ],
             'body' => 'text-secondary-700 dark:text-dark-300 grow rounded-b-xl px-4 py-5',
             'footer' => [
-                'wrapper' => 'text-secondary-700 dark:text-dark-300 dark:border-t-dark-600 rounded-lg rounded-t-none border-t border-t-secondary-200 p-4 px-6',
+                'wrapper' => 'text-secondary-700 dark:text-dark-300 dark:border-t-dark-600 rounded-lg rounded-t-none border-t border-t-secondary-200 p-4',
                 'text' => 'flex items-center justify-end gap-2',
             ],
             'button' => [

--- a/src/resources/views/components/card.blade.php
+++ b/src/resources/views/components/card.blade.php
@@ -9,7 +9,7 @@
                 <img src="{{ $image }}" @class([$personalize['image.rounded.top'], $personalize['image.size']]) />
             </div>
         @endif
-        @if ($header)
+        @if ($header && ! $header instanceof \Illuminate\View\ComponentSlot)
             <div @class([$personalize['header.wrapper.base'], $colors['background']]) x-bind:class="{ '{{ $personalize['header.wrapper.border'] }}' : !minimize }">
                 <div class="{{ $personalize['header.text.size'] }}">
                     {{ $header }}
@@ -41,6 +41,10 @@
                 </div>
                 @endif
             </div>
+        @elseif ($header instanceof \Illuminate\View\ComponentSlot)
+            <div class="{{ $personalize['header.wrapper.border'] }}">
+                {{ $header }}
+            </div>
         @endif
         <div {{ $attributes->class($personalize['body']) }}
              x-show="!minimize"
@@ -61,9 +65,13 @@
                  x-transition:leave="transition ease-in duration-100"
                  x-transition:leave-start="opacity-100 translate-y-0"
                  x-transition:leave-end="opacity-0 -translate-y-10">
-                <div class="{{ $personalize['footer.text'] }}">
+                @if (! $footer instanceof \Illuminate\View\ComponentSlot)
+                    <div class="{{ $personalize['footer.text'] }}">
+                        {{ $footer }}
+                    </div>
+                @else
                     {{ $footer }}
-                </div>
+                @endif
             </div>
         @endif
         @if ($image && $position === 'bottom')


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

Relates to #1069 

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif, or video), and also
add any notes that you think are important.  -->
