### PR TITLE
[2.x] Removing `#` of `carousel` Component

### DIFF
--- a/src/resources/views/components/carousel.blade.php
+++ b/src/resources/views/components/carousel.blade.php
@@ -36,7 +36,7 @@
         ])>
             <template x-for="(image, index) in images" :key="index">
                 <div x-show="current == index + 1" class="{{ $personalize['images.wrapper.first'] }}" x-transition.opacity.duration.1000ms>
-                    <a x-bind:href="image.url ?? '#'" x-bind:target="image.target">
+                    <a x-bind:href="image.url ?? null" x-bind:target="image.target">
                         <template x-if="image.title">
                             <div @class([$personalize['images.wrapper.second'], 'rounded-xl' => $round])>
                                 <h3 class="{{ $personalize['images.content.title'] }}" x-text="image.title"></h3>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

Relates to https://github.com/tallstackui/tallstackui/issues/1085

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif, or video), and also
add any notes that you think are important.  -->
