### PR TITLE
[2.x] Refactor number input handling to dynamically set inputmode and pattern based on min and step values

### DIFF
--- a/src/View/Components/Form/Number.php
+++ b/src/View/Components/Form/Number.php
@@ -38,7 +38,7 @@ class Number extends TallStackUiComponent implements Personalization
         return view('tallstack-ui::components.form.number');
     }
 
-    public function inputMode(): string
+    final public function mode(): string
     {
         if (is_null($this->min) || $this->min < 0) {
             return 'text';
@@ -51,7 +51,7 @@ class Number extends TallStackUiComponent implements Personalization
         return 'numeric';
     }
 
-    public function inputPattern(): string
+    final public function pattern(): string
     {
         if (is_null($this->min) || $this->min < 0) {
             return '-?[0-9]*[.,]?[0-9]*';

--- a/src/View/Components/Form/Number.php
+++ b/src/View/Components/Form/Number.php
@@ -38,6 +38,32 @@ class Number extends TallStackUiComponent implements Personalization
         return view('tallstack-ui::components.form.number');
     }
 
+    public function inputMode(): string
+    {
+        if (is_null($this->min) || $this->min < 0) {
+            return 'text';
+        }
+
+        if ($this->step && $this->step < 1) {
+            return 'decimal';
+        }
+
+        return 'numeric';
+    }
+
+    public function inputPattern(): string
+    {
+        if (is_null($this->min) || $this->min < 0) {
+            return '-?[0-9]*[.,]?[0-9]*';
+        }
+
+        if ($this->step && $this->step < 1) {
+            return '[0-9]*[.,]?[0-9]*';
+        }
+
+        return '[0-9]*';
+    }
+
     public function personalization(): array
     {
         return Arr::dot([

--- a/src/resources/views/components/card.blade.php
+++ b/src/resources/views/components/card.blade.php
@@ -2,7 +2,7 @@
     $personalize = $classes();
 @endphp
 
-<div x-data="tallstackui_card(@js($initializeMinimized))" class="{{ $personalize['wrapper.first'] }}" x-cloak wire:ignore.self>
+<div x-data="tallstackui_card(@js($initializeMinimized))" class="{{ $personalize['wrapper.first'] }}" x-cloak @if ($close) x-show="show" @endif wire:ignore.self>
     <div class="{{ $personalize['wrapper.second'] }}">
         @if ($image && $position !== 'bottom')
             <div class="{{ $personalize['image.wrapper'] }}">

--- a/src/resources/views/components/form/number.blade.php
+++ b/src/resources/views/components/form/number.blade.php
@@ -13,8 +13,8 @@
         <div @class([$personalize['buttons.wrapper'], 'justify-between' => $centralized])>
             <input @if ($id) id="{{ $id }}" @endif
                type="number"
-               inputmode="{{ $inputMode() }}"
-               pattern="{{ $inputPattern() }}"
+               inputmode="{{ $mode() }}"
+               pattern="{{ $pattern() }}"
                @if ($min) min="{{ $min }}" @endif
                @if ($max) max="{{ $max }}" @endif
                @if ($step) step="{{ $step }}" @endif

--- a/src/resources/views/components/form/number.blade.php
+++ b/src/resources/views/components/form/number.blade.php
@@ -13,7 +13,8 @@
         <div @class([$personalize['buttons.wrapper'], 'justify-between' => $centralized])>
             <input @if ($id) id="{{ $id }}" @endif
                type="number"
-               inputmode="numeric"
+               inputmode="{{ $inputMode() }}"
+               pattern="{{ $inputPattern() }}"
                @if ($min) min="{{ $min }}" @endif
                @if ($max) max="{{ $max }}" @endif
                @if ($step) step="{{ $step }}" @endif

--- a/tests/Browser/Form/NumberTest.php
+++ b/tests/Browser/Form/NumberTest.php
@@ -351,6 +351,68 @@ class NumberTest extends BrowserTestCase
     }
 
     #[Test]
+    public function can_input_decimal_with_comma_on_mobile(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public float $quantity = 0.0;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <p dusk="quantity">{{ $quantity }}</p>
+                    <x-number wire:model="quantity" min="0" step="0.01" />
+                    <x-button dusk="sync" wire:click="sync">Save</x-button>
+                </div>
+                HTML;
+            }
+
+            public function sync(): void
+            {
+                //
+            }
+        })
+            ->assertSee('Save')
+            ->type('@tallstackui_form_number_input', '10,5')
+            ->click('@sync')
+            ->waitForTextIn('@quantity', '10.5');
+    }
+
+    #[Test]
+    public function can_input_negative_numbers_when_allowed(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public ?int $quantity = 0;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <p dusk="quantity">{{ $quantity }}</p>
+                    <x-number wire:model="quantity" min="-100" max="100" />
+                    <x-button dusk="sync" wire:click="sync">Save</x-button>
+                </div>
+                HTML;
+            }
+
+            public function sync(): void
+            {
+                //
+            }
+        })
+            ->assertSee('Save')
+            ->type('@tallstackui_form_number_input', '-50')
+            ->click('@sync')
+            ->waitForTextIn('@quantity', '-50')
+            ->clear('@tallstackui_form_number_input')
+            ->type('@tallstackui_form_number_input', '75')
+            ->click('@sync')
+            ->waitForTextIn('@quantity', '75');
+    }
+
+    #[Test]
     public function cannot_decrease_beyond_min(): void
     {
         Livewire::visit(new class extends Component
@@ -485,5 +547,85 @@ class NumberTest extends BrowserTestCase
             ->click('@tallstackui_form_number_decrement')
             ->click('@sync')
             ->waitForTextIn('@quantity', '0');
+    }
+
+    #[Test]
+    public function uses_decimal_inputmode_for_positive_decimals(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public float $quantity = 0.0;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-number wire:model="quantity" min="0" step="0.01" />
+                </div>
+                HTML;
+            }
+        })
+            ->assertAttribute('@tallstackui_form_number_input', 'inputmode', 'decimal')
+            ->assertAttribute('@tallstackui_form_number_input', 'pattern', '[0-9]*[.,]?[0-9]*');
+    }
+
+    #[Test]
+    public function uses_numeric_inputmode_for_positive_integers(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public ?int $quantity = 0;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-number wire:model="quantity" min="0" step="1" />
+                </div>
+                HTML;
+            }
+        })
+            ->assertAttribute('@tallstackui_form_number_input', 'inputmode', 'numeric')
+            ->assertAttribute('@tallstackui_form_number_input', 'pattern', '[0-9]*');
+    }
+
+    #[Test]
+    public function uses_text_inputmode_for_negative_numbers(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public ?int $quantity = 0;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-number wire:model="quantity" min="-100" step="1" />
+                </div>
+                HTML;
+            }
+        })
+            ->assertAttribute('@tallstackui_form_number_input', 'inputmode', 'text')
+            ->assertAttribute('@tallstackui_form_number_input', 'pattern', '-?[0-9]*[.,]?[0-9]*');
+    }
+
+    #[Test]
+    public function uses_text_inputmode_when_min_not_set(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public ?int $quantity = 0;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-number wire:model="quantity" step="1" />
+                </div>
+                HTML;
+            }
+        })
+            ->assertAttribute('@tallstackui_form_number_input', 'inputmode', 'text')
+            ->assertAttribute('@tallstackui_form_number_input', 'pattern', '-?[0-9]*[.,]?[0-9]*');
     }
 }

--- a/tests/Feature/Components/Form/NumberTest.php
+++ b/tests/Feature/Components/Form/NumberTest.php
@@ -17,3 +17,33 @@ it('can render with label and hint')
     ->toContain('<input')
     ->toContain('Foo bar')
     ->toContain('Bar baz');
+
+it('uses numeric inputmode for positive integers')
+    ->expect('<x-number min="0" step="1" />')
+    ->render()
+    ->toContain('inputmode="numeric"')
+    ->toContain('pattern="[0-9]*"');
+
+it('uses decimal inputmode for positive decimals')
+    ->expect('<x-number min="0" step="0.01" />')
+    ->render()
+    ->toContain('inputmode="decimal"')
+    ->toContain('pattern="[0-9]*[.,]?[0-9]*"');
+
+it('uses text inputmode when min is negative')
+    ->expect('<x-number min="-100" step="1" />')
+    ->render()
+    ->toContain('inputmode="text"')
+    ->toContain('pattern="-?[0-9]*[.,]?[0-9]*"');
+
+it('uses text inputmode when min is not set')
+    ->expect('<x-number step="1" />')
+    ->render()
+    ->toContain('inputmode="text"')
+    ->toContain('pattern="-?[0-9]*[.,]?[0-9]*"');
+
+it('uses decimal inputmode for decimals with positive min')
+    ->expect('<x-number min="10" step="0.5" />')
+    ->render()
+    ->toContain('inputmode="decimal"')
+    ->toContain('pattern="[0-9]*[.,]?[0-9]*"');


### PR DESCRIPTION
Hey AJ,

that was bothering me for a long time :D on mobile ios no decimal button is shown for inputmode numeric even if the number input has a step below 1. That PR should fix this.

<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [ ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ ] I created a new branch on my fork for this pull request 
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

<!-- Describe your PR, which more details as possible. -->

### Demonstration & Notes:

<!-- Insert a demonstration about the changes or 
the features (image, gif, or video), and also
add any notes that you think are important.  -->
