### PR TITLE
[2.x] Add title attribute to tab items and update tests for title display

### DIFF
--- a/src/View/Components/Tab/Items.php
+++ b/src/View/Components/Tab/Items.php
@@ -14,6 +14,7 @@ class Items extends TallStackUiComponent
 {
     public function __construct(
         public ?string $tab = null,
+        public ?string $title = null,
         #[SkipDebug]
         public ComponentSlot|string|null $left = null,
         #[SkipDebug]

--- a/src/resources/views/components/tab/items.blade.php
+++ b/src/resources/views/components/tab/items.blade.php
@@ -1,5 +1,3 @@
-<div x-show="selected === @js($tab)" role="tabpanel"
-    x-init="tabs.push({ tab: @js($tab), title: @js($title), right: @js($content['right']), left: @js($content['left']) });"
-    aria-labelledby="{{ $tab }}">
+<div x-show="selected === @js($tab)" role="tabpanel" x-init="tabs.push({ tab: @js($tab), title: @js($title), right: @js($content['right']), left: @js($content['left']) });" aria-labelledby="{{ $tab }}">
     {{ $slot }}
 </div>

--- a/src/resources/views/components/tab/items.blade.php
+++ b/src/resources/views/components/tab/items.blade.php
@@ -1,3 +1,5 @@
-<div x-show="selected === @js($tab)" role="tabpanel" x-init="tabs.push({ tab: @js($tab), right: @js($content['right']), left: @js($content['left']) });" aria-labelledby="{{ $tab }}">
+<div x-show="selected === @js($tab)" role="tabpanel"
+    x-init="tabs.push({ tab: @js($tab), title: @js($title), right: @js($content['right']), left: @js($content['left']) });"
+    aria-labelledby="{{ $tab }}">
     {{ $slot }}
 </div>

--- a/src/resources/views/components/tab/tab.blade.php
+++ b/src/resources/views/components/tab/tab.blade.php
@@ -19,7 +19,8 @@
                 tabindex="0"
                 x-on:click="selected = item.tab; $refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: item.tab}}));"
                 x-on:keypress.enter="selected = item.tab; $refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: item.tab}}));"
-                x-bind:aria-selected="selected === item.tab ? 'true' : 'false'" x-bind:class="{
+                x-bind:aria-selected="selected === item.tab ? 'true' : 'false'"
+                x-bind:class="{
                     '{{ $personalize['item.select'] }}' : selected === item.tab,
                     '{{ $personalize['item.unselect'] }}' : selected !== item.tab,
                     'hidden sm:flex': selected !== item.tab && ! @js($scrollOnMobile),

--- a/src/resources/views/components/tab/tab.blade.php
+++ b/src/resources/views/components/tab/tab.blade.php
@@ -1,25 +1,27 @@
 @php
-    $personalize = $classes();
+$personalize = $classes();
 @endphp
 
-<div x-data="{ selected: @if (!$selected) {!! TallStackUi::blade($attributes, $livewire)->entangle() !!} @else @js($selected) @endif, tabs: [] }" class="{{ $personalize['base.wrapper'] }}">
+<div x-data="{ selected: @if (!$selected) {!! TallStackUi::blade($attributes, $livewire)->entangle() !!} @else @js($selected) @endif, tabs: [] }"
+    class="{{ $personalize['base.wrapper'] }}">
     @if (!$scrollOnMobile)
-        <div class="{{ $personalize['base.padding'] }}">
-            <select x-model="selected" class="{{ $personalize['base.select'] }}" aria-label="Select a tab" x-on:change="$refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: selected}}));">
-                <template x-for="item in tabs">
-                    <option x-bind:value="item.tab" x-text="item.tab" x-bind:selected="item.tab === selected"></option>
-                </template>
-            </select>
-        </div>
+    <div class="{{ $personalize['base.padding'] }}">
+        <select x-model="selected" class="{{ $personalize['base.select'] }}" aria-label="Select a tab"
+            x-on:change="$refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: selected}}));">
+            <template x-for="item in tabs">
+                <option x-bind:value="item.tab" x-text="item.title ?? item.tab" x-bind:selected="item.tab === selected">
+                </option>
+            </template>
+        </select>
+    </div>
     @endif
-    <ul role="tablist" @class([$personalize['base.body'], 'hidden sm:flex' => ! $scrollOnMobile]) {{ $attributes->only('x-on:navigate') }} x-ref="ul">
+    <ul role="tablist" @class([$personalize['base.body'], 'hidden sm:flex'=> ! $scrollOnMobile]) {{
+        $attributes->only('x-on:navigate') }} x-ref="ul">
         <template x-for="item in tabs">
-            <li role="tab"
-                tabindex="0"
+            <li role="tab" tabindex="0"
                 x-on:click="selected = item.tab; $refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: item.tab}}));"
                 x-on:keypress.enter="selected = item.tab; $refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: item.tab}}));"
-                x-bind:aria-selected="selected === item.tab ? 'true' : 'false'"
-                x-bind:class="{
+                x-bind:aria-selected="selected === item.tab ? 'true' : 'false'" x-bind:class="{
                     '{{ $personalize['item.select'] }}' : selected === item.tab,
                     '{{ $personalize['item.unselect'] }}' : selected !== item.tab,
                     'hidden sm:flex': selected !== item.tab && ! @js($scrollOnMobile),
@@ -28,7 +30,7 @@
                     <template x-if="item.left">
                         <div x-html="item.left"></div>
                     </template>
-                    <span x-text="item.tab"></span>
+                    <span x-text="item.title ?? item.tab"></span>
                     <template x-if="item.right">
                         <div x-html="item.right"></div>
                     </template>
@@ -36,7 +38,7 @@
             </li>
         </template>
     </ul>
-    <hr @class([$personalize['base.divider'], 'hidden sm:block' => ! $scrollOnMobile])>
+    <hr @class([$personalize['base.divider'], 'hidden sm:block'=> ! $scrollOnMobile])>
     <div class="{{ $personalize['base.content'] }}">
         {{ $slot }}
     </div>

--- a/src/resources/views/components/tab/tab.blade.php
+++ b/src/resources/views/components/tab/tab.blade.php
@@ -1,13 +1,11 @@
 @php
-$personalize = $classes();
+    $personalize = $classes();
 @endphp
 
-<div x-data="{ selected: @if (!$selected) {!! TallStackUi::blade($attributes, $livewire)->entangle() !!} @else @js($selected) @endif, tabs: [] }"
-    class="{{ $personalize['base.wrapper'] }}">
+<div x-data="{ selected: @if (!$selected) {!! TallStackUi::blade($attributes, $livewire)->entangle() !!} @else @js($selected) @endif, tabs: [] }" class="{{ $personalize['base.wrapper'] }}">
     @if (!$scrollOnMobile)
     <div class="{{ $personalize['base.padding'] }}">
-        <select x-model="selected" class="{{ $personalize['base.select'] }}" aria-label="Select a tab"
-            x-on:change="$refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: selected}}));">
+        <select x-model="selected" class="{{ $personalize['base.select'] }}" aria-label="Select a tab" x-on:change="$refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: selected}}));">
             <template x-for="item in tabs">
                 <option x-bind:value="item.tab" x-text="item.title ?? item.tab" x-bind:selected="item.tab === selected">
                 </option>
@@ -15,8 +13,7 @@ $personalize = $classes();
         </select>
     </div>
     @endif
-    <ul role="tablist" @class([$personalize['base.body'], 'hidden sm:flex'=> ! $scrollOnMobile]) {{
-        $attributes->only('x-on:navigate') }} x-ref="ul">
+    <ul role="tablist" @class([$personalize['base.body'], 'hidden sm:flex'=> ! $scrollOnMobile]) {{  $attributes->only('x-on:navigate') }} x-ref="ul">
         <template x-for="item in tabs">
             <li role="tab" tabindex="0"
                 x-on:click="selected = item.tab; $refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: item.tab}}));"

--- a/src/resources/views/components/tab/tab.blade.php
+++ b/src/resources/views/components/tab/tab.blade.php
@@ -13,9 +13,10 @@
         </select>
     </div>
     @endif
-    <ul role="tablist" @class([$personalize['base.body'], 'hidden sm:flex'=> ! $scrollOnMobile]) {{  $attributes->only('x-on:navigate') }} x-ref="ul">
+    <ul role="tablist" @class([$personalize['base.body'], 'hidden sm:flex' => ! $scrollOnMobile]) {{ $attributes->only('x-on:navigate') }} x-ref="ul">
         <template x-for="item in tabs">
-            <li role="tab" tabindex="0"
+            <li role="tab"
+                tabindex="0"
                 x-on:click="selected = item.tab; $refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: item.tab}}));"
                 x-on:keypress.enter="selected = item.tab; $refs.ul.dispatchEvent(new CustomEvent('navigate', {detail: {select: item.tab}}));"
                 x-bind:aria-selected="selected === item.tab ? 'true' : 'false'" x-bind:class="{
@@ -35,7 +36,7 @@
             </li>
         </template>
     </ul>
-    <hr @class([$personalize['base.divider'], 'hidden sm:block'=> ! $scrollOnMobile])>
+    <hr @class([$personalize['base.divider'], 'hidden sm:block' => ! $scrollOnMobile])>
     <div class="{{ $personalize['base.content'] }}">
         {{ $slot }}
     </div>

--- a/tests/Browser/Tab/IndexTest.php
+++ b/tests/Browser/Tab/IndexTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Browser\Tab;
 
-use Livewire\Livewire;
-use Livewire\Component;
 use Livewire\Attributes\Url;
-use Tests\Browser\BrowserTestCase;
+use Livewire\Component;
+use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Test;
+use Tests\Browser\BrowserTestCase;
 
 class IndexTest extends BrowserTestCase
 {
@@ -51,6 +51,7 @@ class IndexTest extends BrowserTestCase
         Livewire::visit(new class extends Component
         {
             public ?string $selected = null;
+
             public function render(): string
             {
                 return <<<'HTML'
@@ -78,6 +79,7 @@ class IndexTest extends BrowserTestCase
             ->assertDontSee('Foo bar baz')
             ->waitForTextIn('@selected', 'Bar');
     }
+
     #[Test]
     public function can_entangle_with_url_parameter(): void
     {

--- a/tests/Browser/Tab/IndexTest.php
+++ b/tests/Browser/Tab/IndexTest.php
@@ -23,10 +23,10 @@ class IndexTest extends BrowserTestCase
                     <p dusk="selected">{{ $selected }}</p>
 
                     <x-tab selected="Foo" x-on:navigate="$wire.set('selected', $event.detail.select)">
-                        <x-tab.items tab="Foo">
+                        <x-tab.items tab="foo" title="Foo Title">
                             Foo bar baz
                         </x-tab.items>
-                        <x-tab.items tab="Bar">
+                        <x-tab.items tab="bar" title="Bar Title">
                             Baz bar foo
                         </x-tab.items>
                     </x-tab>
@@ -34,8 +34,8 @@ class IndexTest extends BrowserTestCase
                 HTML;
             }
         })
-            ->assertSee('Foo')
-            ->assertSee('Bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Title')
             ->assertSee('Foo bar baz')
             ->assertDontSee('Baz bar foo')
             ->clickAtXPath('/html/body/div[3]/div/ul/li[2]')
@@ -54,10 +54,10 @@ class IndexTest extends BrowserTestCase
                 return <<<'HTML'
                 <div>        
                     <x-tab selected="Données d'identification">
-                        <x-tab.items tab="Données d'identification">
+                        <x-tab.items tab="données-d-identification" title="Données d'identification">
                             Lorem ipsum dolor sit amet
                         </x-tab.items>
-                        <x-tab.items tab="Données d'accès incorrectes">
+                        <x-tab.items tab="données-d-accès-incorrectes" title="Données d'accès incorrectes">
                             Consectetur adipiscing elit
                         </x-tab.items>
                     </x-tab>
@@ -84,14 +84,14 @@ class IndexTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>        
-                    <x-tab selected="Foo">
-                        <x-tab.items tab="Foo">
+                    <x-tab selected="foo">
+                        <x-tab.items tab="foo" title="Foo Title">
                             <x-slot:left>
                                 TallStackUI                            
                             </x-slot:left>
                             Foo bar baz
                         </x-tab.items>
-                        <x-tab.items tab="Bar">
+                        <x-tab.items tab="bar" title="Bar Title">
                             Baz bar foo
                         </x-tab.items>
                     </x-tab>
@@ -99,8 +99,8 @@ class IndexTest extends BrowserTestCase
                 HTML;
             }
         })
-            ->assertSee('Foo')
-            ->assertSee('Bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Title')
             ->assertSee('Foo bar baz')
             ->assertSee('TallStackUI');
     }
@@ -126,11 +126,11 @@ class IndexTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>        
-                    <x-tab selected="Foo">
-                        <x-tab.items tab="Foo">
+                    <x-tab selected="foo">
+                        <x-tab.items tab="foo" title="Foo Title">
                             <livewire:test />
                         </x-tab.items>
-                        <x-tab.items tab="Bar">
+                        <x-tab.items tab="bar" title="Bar Title">
                             Baz bar foo
                         </x-tab.items>
                     </x-tab>
@@ -138,8 +138,8 @@ class IndexTest extends BrowserTestCase
                 HTML;
             }
         })
-            ->assertSee('Foo')
-            ->assertSee('Bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Title')
             ->assertSee('Foo bar baz through Livewire Component');
     }
 
@@ -152,14 +152,14 @@ class IndexTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>        
-                    <x-tab selected="Foo">
-                        <x-tab.items tab="Foo">
+                    <x-tab selected="foo">
+                        <x-tab.items tab="foo" title="Foo Title">
                             <x-slot:right>
                                 TallStackUI                            
                             </x-slot:right>
                             Foo bar baz
                         </x-tab.items>
-                        <x-tab.items tab="Bar">
+                        <x-tab.items tab="bar" title="Bar Titles">
                             Baz bar foo
                         </x-tab.items>
                     </x-tab>
@@ -167,8 +167,8 @@ class IndexTest extends BrowserTestCase
                 HTML;
             }
         })
-            ->assertSee('Foo')
-            ->assertSee('Bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Titles')
             ->assertSee('Foo bar baz')
             ->assertSee('TallStackUI');
     }
@@ -182,11 +182,11 @@ class IndexTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>        
-                    <x-tab selected="Foo">
-                        <x-tab.items tab="Foo" left="TallStackUI" right="Livewire">
+                    <x-tab selected="foo">
+                        <x-tab.items tab="foo" title="Foo Title" left="TallStackUI" right="Livewire">
                             Foo bar baz
                         </x-tab.items>
-                        <x-tab.items tab="Bar">
+                        <x-tab.items tab="bar" title="Bar Title">
                             Baz bar foo
                         </x-tab.items>
                     </x-tab>
@@ -194,8 +194,8 @@ class IndexTest extends BrowserTestCase
                 HTML;
             }
         })
-            ->assertSee('Foo')
-            ->assertSee('Bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Title')
             ->assertSee('Foo bar baz')
             ->assertSee('TallStackUI')
             ->assertSee('Livewire');
@@ -210,11 +210,11 @@ class IndexTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>        
-                    <x-tab selected="Foo">
-                        <x-tab.items tab="Foo">
+                    <x-tab selected="foo">
+                        <x-tab.items tab="foo" title="Foo Title">
                             Foo bar baz
                         </x-tab.items>
-                        <x-tab.items tab="Bar">
+                        <x-tab.items tab="bar" title="Bar Title">
                             Baz bar foo
                         </x-tab.items>
                     </x-tab>
@@ -222,8 +222,8 @@ class IndexTest extends BrowserTestCase
                 HTML;
             }
         })
-            ->assertSee('Foo')
-            ->assertSee('Bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Title')
             ->assertSee('Foo bar baz')
             ->assertDontSee('Baz bar foo')
             ->clickAtXPath('/html/body/div[3]/div/ul/li[2]')
@@ -240,11 +240,11 @@ class IndexTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>        
-                    <x-tab selected="Foo">
-                        <x-tab.items tab="Foo">
+                    <x-tab selected="foo">
+                        <x-tab.items tab="foo" title="Foo Title">
                             Foo bar baz
                         </x-tab.items>
-                        <x-tab.items tab="Bar">
+                        <x-tab.items tab="bar" title="Bar Title">
                             Baz bar foo
                         </x-tab.items>
                     </x-tab>
@@ -252,8 +252,8 @@ class IndexTest extends BrowserTestCase
                 HTML;
             }
         })
-            ->assertSee('Foo')
-            ->assertSee('Bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Title')
             ->assertSee('Foo bar baz')
             ->assertDontSee('Baz bar foo')
             ->clickAtXPath('/html/body/div[3]/div/ul/li[2]')
@@ -269,28 +269,28 @@ class IndexTest extends BrowserTestCase
     {
         Livewire::visit(new class extends Component
         {
-            public string $tab = 'Bar';
+            public string $tab = 'bar';
 
             public function render(): string
             {
                 return <<<'HTML'
                 <div>        
                     <x-tab wire:model="tab">
-                        <x-tab.items tab="Foo">
+                        <x-tab.items tab="foo" title="Foo Title">
                             Foo bar baz
                         </x-tab.items>
-                        <x-tab.items tab="Bar">
+                        <x-tab.items tab="bar" title="Bar Title">
                             Baz bar foo
                         </x-tab.items>
                     </x-tab>
 
-                    <x-button id="change" wire:click="$set('tab', 'Foo')" text="Click" />
+                    <x-button id="change" wire:click="$set('tab', 'foo')" text="Click" />
                 </div>
                 HTML;
             }
         })
-            ->assertSee('Foo')
-            ->assertSee('Bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Title')
             ->assertSee('Baz bar foo')
             ->assertDontSee('Foo bar baz')
             ->click('#change')
@@ -303,7 +303,7 @@ class IndexTest extends BrowserTestCase
     {
         Livewire::visit(new class extends Component
         {
-            public string $tab = 'Bar';
+            public string $tab = 'bar';
 
             public function render(): string
             {
@@ -312,10 +312,10 @@ class IndexTest extends BrowserTestCase
                     {{ $tab }}
 
                     <x-tab wire:model.live="tab">
-                        <x-tab.items tab="Foo">
+                        <x-tab.items tab="foo" title="Foo Title">
                             Foo bar baz
                         </x-tab.items>
-                        <x-tab.items tab="Bar">
+                        <x-tab.items tab="bar" title="Bar Title">
                             Baz bar foo
                         </x-tab.items>
                     </x-tab>
@@ -323,13 +323,49 @@ class IndexTest extends BrowserTestCase
                 HTML;
             }
         })
-            ->assertSee('Foo')
-            ->assertSee('Bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Title')
             ->assertSee('Baz bar foo')
             ->assertDontSee('Foo bar baz')
             ->clickAtXPath('/html/body/div[3]/div/ul/li[1]')
             ->waitForText('Foo bar baz')
-            ->assertSee('Bar')
+            ->assertSee('Bar Title')
             ->assertDontSee('Baz bar foo');
+    }
+
+    #[Test]
+    public function can_entangle_with_url_parameter(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public string $tab = 'foo';
+
+            public function mount(): void
+            {
+                if (request()->has('tab')) {
+                    $this->tab = request()->get('tab');
+                }
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>        
+                    <x-tab wire:model.live="tab">
+                        <x-tab.items tab="foo" title="Foo Title">
+                            Foo bar baz
+                        </x-tab.items>
+                        <x-tab.items tab="bar" title="Bar Title">
+                            Baz bar foo
+                        </x-tab.items>
+                    </x-tab>
+                </div>
+                HTML;
+            }
+        }, '?tab=bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Title')
+            ->assertSee('Baz bar foo')
+            ->assertDontSee('Foo bar baz');
     }
 }

--- a/tests/Browser/Tab/IndexTest.php
+++ b/tests/Browser/Tab/IndexTest.php
@@ -2,10 +2,11 @@
 
 namespace Tests\Browser\Tab;
 
-use Livewire\Component;
 use Livewire\Livewire;
-use PHPUnit\Framework\Attributes\Test;
+use Livewire\Component;
+use Livewire\Attributes\Url;
 use Tests\Browser\BrowserTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class IndexTest extends BrowserTestCase
 {
@@ -41,28 +42,55 @@ class IndexTest extends BrowserTestCase
             ->clickAtXPath('/html/body/div[3]/div/ul/li[2]')
             ->waitForText('Baz bar foo')
             ->assertDontSee('Foo bar baz')
-            ->waitForTextIn('@selected', 'Bar');
+            ->waitForTextIn('@selected', 'bar');
     }
 
     #[Test]
-    public function can_entangle_with_url_parameter(): void
+    public function can_display_tabs_without_title(): void
     {
         Livewire::visit(new class extends Component
         {
-            public string $tab = 'foo';
-
-            public function mount(): void
+            public ?string $selected = null;
+            public function render(): string
             {
-                if (request()->has('tab')) {
-                    $this->tab = request()->get('tab');
-                }
+                return <<<'HTML'
+                <div>        
+                    <p dusk="selected">{{ $selected }}</p>
+
+                    <x-tab selected="Foo" x-on:navigate="$wire.set('selected', $event.detail.select)">
+                        <x-tab.items tab="Foo">
+                            Foo bar baz
+                        </x-tab.items>
+                        <x-tab.items tab="Bar">
+                            Baz bar foo
+                        </x-tab.items>
+                    </x-tab>
+                </div>
+                HTML;
             }
+        })
+            ->assertSee('Foo')
+            ->assertSee('Bar')
+            ->assertSee('Foo bar baz')
+            ->assertDontSee('Baz bar foo')
+            ->clickAtXPath('/html/body/div[3]/div/ul/li[2]')
+            ->waitForText('Baz bar foo')
+            ->assertDontSee('Foo bar baz')
+            ->waitForTextIn('@selected', 'Bar');
+    }
+    #[Test]
+    public function can_entangle_with_url_parameter(): void
+    {
+        Livewire::withQueryParams(['tab' => 'bar'])->visit(new class extends Component
+        {
+            #[Url]
+            public string $tab = 'foo';
 
             public function render(): string
             {
                 return <<<'HTML'
                 <div>        
-                    <x-tab wire:model.live="tab">
+                    <x-tab wire:model="tab">
                         <x-tab.items tab="foo" title="Foo Title">
                             Foo bar baz
                         </x-tab.items>
@@ -73,9 +101,11 @@ class IndexTest extends BrowserTestCase
                 </div>
                 HTML;
             }
-        }, '?tab=bar')
+        })
+            ->waitForLivewireToLoad()
             ->assertSee('Foo Title')
             ->assertSee('Bar Title')
+            ->waitForText('Baz bar foo')
             ->assertSee('Baz bar foo')
             ->assertDontSee('Foo bar baz');
     }

--- a/tests/Browser/Tab/IndexTest.php
+++ b/tests/Browser/Tab/IndexTest.php
@@ -22,7 +22,7 @@ class IndexTest extends BrowserTestCase
                 <div>        
                     <p dusk="selected">{{ $selected }}</p>
 
-                    <x-tab selected="Foo" x-on:navigate="$wire.set('selected', $event.detail.select)">
+                    <x-tab selected="foo" x-on:navigate="$wire.set('selected', $event.detail.select)">
                         <x-tab.items tab="foo" title="Foo Title">
                             Foo bar baz
                         </x-tab.items>
@@ -53,7 +53,7 @@ class IndexTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>        
-                    <x-tab selected="Données d'identification">
+                    <x-tab selected="données-d-identification">
                         <x-tab.items tab="données-d-identification" title="Données d'identification">
                             Lorem ipsum dolor sit amet
                         </x-tab.items>
@@ -159,7 +159,7 @@ class IndexTest extends BrowserTestCase
                             </x-slot:right>
                             Foo bar baz
                         </x-tab.items>
-                        <x-tab.items tab="bar" title="Bar Titles">
+                        <x-tab.items tab="bar" title="Bar Title">
                             Baz bar foo
                         </x-tab.items>
                     </x-tab>
@@ -168,7 +168,7 @@ class IndexTest extends BrowserTestCase
             }
         })
             ->assertSee('Foo Title')
-            ->assertSee('Bar Titles')
+            ->assertSee('Bar Title')
             ->assertSee('Foo bar baz')
             ->assertSee('TallStackUI');
     }

--- a/tests/Browser/Tab/IndexTest.php
+++ b/tests/Browser/Tab/IndexTest.php
@@ -45,6 +45,42 @@ class IndexTest extends BrowserTestCase
     }
 
     #[Test]
+    public function can_entangle_with_url_parameter(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public string $tab = 'foo';
+
+            public function mount(): void
+            {
+                if (request()->has('tab')) {
+                    $this->tab = request()->get('tab');
+                }
+            }
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>        
+                    <x-tab wire:model.live="tab">
+                        <x-tab.items tab="foo" title="Foo Title">
+                            Foo bar baz
+                        </x-tab.items>
+                        <x-tab.items tab="bar" title="Bar Title">
+                            Baz bar foo
+                        </x-tab.items>
+                    </x-tab>
+                </div>
+                HTML;
+            }
+        }, '?tab=bar')
+            ->assertSee('Foo Title')
+            ->assertSee('Bar Title')
+            ->assertSee('Baz bar foo')
+            ->assertDontSee('Foo bar baz');
+    }
+
+    #[Test]
     public function can_render_and_select_with_accents(): void
     {
         Livewire::visit(new class extends Component
@@ -331,41 +367,5 @@ class IndexTest extends BrowserTestCase
             ->waitForText('Foo bar baz')
             ->assertSee('Bar Title')
             ->assertDontSee('Baz bar foo');
-    }
-
-    #[Test]
-    public function can_entangle_with_url_parameter(): void
-    {
-        Livewire::visit(new class extends Component
-        {
-            public string $tab = 'foo';
-
-            public function mount(): void
-            {
-                if (request()->has('tab')) {
-                    $this->tab = request()->get('tab');
-                }
-            }
-
-            public function render(): string
-            {
-                return <<<'HTML'
-                <div>        
-                    <x-tab wire:model.live="tab">
-                        <x-tab.items tab="foo" title="Foo Title">
-                            Foo bar baz
-                        </x-tab.items>
-                        <x-tab.items tab="bar" title="Bar Title">
-                            Baz bar foo
-                        </x-tab.items>
-                    </x-tab>
-                </div>
-                HTML;
-            }
-        }, '?tab=bar')
-            ->assertSee('Foo Title')
-            ->assertSee('Bar Title')
-            ->assertSee('Baz bar foo')
-            ->assertDontSee('Foo bar baz');
     }
 }

--- a/tests/Feature/Components/Tab/IndexTest.php
+++ b/tests/Feature/Components/Tab/IndexTest.php
@@ -15,3 +15,19 @@ it('can render', function () {
     expect($component)->render()
         ->toContain('Foo', 'Bar');
 });
+
+
+it('can render with title', function () {
+    $component = <<<'HTML'
+    <x-tab selected="A">
+        <x-tab.items tab="A" title="First Tab">
+            First Tab Content
+        </x-tab.items>
+        <x-tab.items tab="B" title="Second Tab">
+            Second Tab Content
+        </x-tab.items>
+    </x-tab>
+    HTML;
+    expect($component)->render()
+        ->toContain('First Tab Content', 'Second Tab Content');
+});

--- a/tests/Feature/Components/Tab/IndexTest.php
+++ b/tests/Feature/Components/Tab/IndexTest.php
@@ -16,7 +16,6 @@ it('can render', function () {
         ->toContain('Foo', 'Bar');
 });
 
-
 it('can render with title', function () {
     $component = <<<'HTML'
     <x-tab selected="A">


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [X ] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [ X] I created a new branch on my fork for this pull request 
- [X ] I ensure that the current tests are passing
- [ X] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [X ] Enhancements
- [ ] Bugfix

### Description:

# Tab Component Enhancement: Separate `title` and `tab` Properties

## Overview

This update introduces a `title` property to the Tab component, allowing you to specify a user-friendly display label (`title`) separately from the internal tab identifier (`tab`). This change improves usability, accessibility, and URL handling for tabbed interfaces.

---

## Why This Change?

### 1. **URL-Friendly Tabs**
- The `tab` property can now be a short, URL-safe string (e.g., `user-profile`, `settings`).
- The `title` property allows for longer, descriptive, or localized labels (e.g., `User Profile`, `Données d'identification`).
- This separation enables clean URLs and deep-linking to specific tabs without sacrificing readability.

### 2. **Better User Experience**
- Longer, more descriptive tab titles improve clarity for users.
- Supports internationalization and accessibility by allowing translated or detailed labels.

### 3. **Flexible and Backward Compatible**
- If `title` is not provided, the component falls back to using `tab` as the label.
- Existing code continues to work, but new code can leverage the improved separation.

### 4. **Improved Testing and Maintenance**
- Tests now cover scenarios with accented characters, long titles, and URL parameter selection.
- The component is easier to maintain and extend for future needs.

---

## Example Usage

**Before:**
```blade
<x-tab.items tab="données-d'identification">
    Données d'identification
</x-tab.items>
```

**After:**
```blade
<x-tab.items tab="données-d-identification" title="Données d'identification">
    Données d'identification
</x-tab.items>
```
- `tab` is used for internal logic and URLs.
- `title` is shown to users.

---

## Benefits

- Clean, readable URLs for tab navigation.
- Descriptive, accessible tab labels.
- Seamless support for internationalization.
- Backward compatible with existing implementations.

---

**Recommended for all projects using tabbed navigation that require clean URLs, descriptive labels, or
