### PR TITLE
[2.x] Text tooltip when hovering select options

### DIFF
--- a/src/resources/views/components/select/styled.blade.php
+++ b/src/resources/views/components/select/styled.blade.php
@@ -180,7 +180,7 @@
                     </template>
                 @else
                     <template x-for="(option, index) in available" :key="option.__tsui_key ?? index">
-                        <li x-on:click.stop="select(option)"
+                        <li x-bind:title="option[selectable.label] ?? option" x-on:click.stop="select(option)"
                             x-on:keypress.enter="select(option)"
                             x-bind:class="{'{{ $personalize['box.list.item.selected'] }}': !common ? selected(option) : selects.includes(option), '{{ $personalize['box.list.item.disabled'] }}': option.disabled === true}"
                             role="option"


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to 
TallStackUI. Please, fill in the form below 
correctly. This will help us to understand your PR.
-->

### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request 
- [x] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

This PR enhances the Select options list to improve discoverability of long labels by adding a native tooltip via the title attribute on each option item.

#### Change summary
- Adds `x-bind:title="option[selectable.label] ?? option"` to the `<li>` that represents each option in the dropdown list.
- Keeps existing behavior for selection/keyboard handling unchanged.
- No breaking changes. If the label is present, it’s used; otherwise it falls back to the option itself.


<!-- Describe your PR, which more details as possible. -->

### Demonstration & Notes:

```
<!-- before -->
<li
  x-on:click.stop="select(option)"
  x-on:keypress.enter="select(option)"
  x-bind:class="{'{{ $personalize['box.list.item.selected'] }}': !common ? selected(option) : selects.includes(option), '{{ $personalize['box.list.item.disabled'] }}': option.disabled === true}"
  role="option"
>

<!-- after -->
<li
  x-bind:title="option[selectable.label] ?? option"
  x-on:click.stop="select(option)"
  x-on:keypress.enter="select(option)"
  x-bind:class="{'{{ $personalize['box.list.item.selected'] }}': !common ? selected(option) : selects.includes(option), '{{ $personalize['box.list.item.disabled'] }}': option.disabled === true}"
  role="option"
>
```
![sleect_tooltip_demo](https://github.com/user-attachments/assets/e9c8ca88-97fe-4e08-8084-7af476b9f51a)

<!-- Insert a demonstration about the changes or 
the features (image, gif, or video), and also
add any notes that you think are important.  -->
