### PR TITLE
fix: add support for wire:* attributes in select.styled component

### DIFF
--- a/src/resources/views/components/select/styled.blade.php
+++ b/src/resources/views/components/select/styled.blade.php
@@ -29,6 +29,7 @@
      x-cloak
      translate="no"
      x-on:keydown="navigate($event)"
+     {{ $attributes->whereStartsWith('wire:') }}
      wire:ignore.self>
     <div hidden x-ref="options">{{ TallStackUi::blade()->json($options) }}</div>
     @if ($request['params'] ?? null) <div hidden x-ref="params">{{ TallStackUi::blade()->json($request['params']) }}</div> @endif

--- a/tests/Feature/Components/Form/Select/SelectStyledTest.php
+++ b/tests/Feature/Components/Form/Select/SelectStyledTest.php
@@ -103,3 +103,13 @@ HTML;
 
     expect($component)->render();
 });
+
+it('can accept wire attributes', function () {
+    $component = <<<'HTML'
+    <x-select.styled label="Foo bar baz" :options="['foo', 'bar', 'baz']" wire:key="my-select-key" />
+HTML;
+
+    expect($component)->render()
+        ->toContain('wire:key="my-select-key"')
+        ->toContain('Foo bar baz');
+});


### PR DESCRIPTION
## Description
This PR adds support for `wire:*` attributes in the `select.styled` component.

## Problem
When using multiple `select.styled` components stacked vertically, closing one select would cause DOM conflicts. The select would close visually but remain open in the DOM, causing unexpected behavior with other selects on the page.

## Solution
- Added `wire:*` attributes support to the root div element
- Allows users to use `wire:key` to properly identify each select instance
- Gives users greater control over component behavior through Livewire wire directives

## Changes
- Modified `src/resources/views/components/select/styled.blade.php` to accept `wire:*` attributes
- Added test in `tests/Feature/Components/Form/Select/SelectStyledTest.php` to verify `wire:key` is properly rendered

## Testing
- ✅ All existing tests pass (879 passed)
- ✅ New test added to verify wire attributes functionality
- ✅ Tested manually with multiple selects on the same page

## Test Project
A complete test project demonstrating this fix is available at:
🔗 **https://github.com/vresende/tallstackui-select-test**

The test project includes:
- Multiple select.styled components with `wire:key` attributes
- Live demonstration of the fix working with stacked selects
- Instructions on how to run and test locally

## Backward Compatibility
This change is fully backward compatible with existing implementations.