### PR TITLE
feat: min and max attributes to currency component

### DIFF
--- a/js/components/form/currency.js
+++ b/js/components/form/currency.js
@@ -7,6 +7,8 @@ export default (
   livewire,
   property,
   value,
+  min,
+  max,
   locale
 ) => ({
   model: model,
@@ -18,6 +20,8 @@ export default (
   livewire: livewire,
   property: property,
   value: value,
+  min: min,
+  max: max,
   locale: locale,
   init() {
     if (!this.livewire) this.model = this.value;
@@ -41,6 +45,37 @@ export default (
     });
 
     this.$watch('input', (value) => this.format(value));
+  },
+  /**
+   * Validate the input value.
+   *
+   * @returns {void}
+   */
+  validate() {
+    if (this.min === null && this.max === null) return;
+
+    let current = this.input;
+    let number;
+
+    if (typeof current === 'number') {
+      number = current;
+    } else {
+      const digits = String(current).replace(/\D/g, '');
+
+      if (digits === '') return;
+
+      number = parseFloat(digits) / 100;
+    }
+
+    if (isNaN(number)) return;
+
+    if (this.min !== null && number < this.min) {
+      this.clear();
+    }
+
+    if (this.max !== null && number > this.max) {
+      this.clear();
+    }
   },
   /**
    * Format the input value.

--- a/src/View/Components/Form/Currency.php
+++ b/src/View/Components/Form/Currency.php
@@ -24,6 +24,8 @@ class Currency extends TallStackUiComponent implements Personalization
         public ?string $locale = 'en-US',
         public ?int $decimals = 2,
         public ?int $precision = 4,
+        public int|float|null $min = null,
+        public int|float|null $max = null,
         public bool|string|null $symbol = null,
         public bool|string|null $currency = null,
         public ?bool $mutate = null,

--- a/src/resources/views/components/form/currency.blade.php
+++ b/src/resources/views/components/form/currency.blade.php
@@ -15,16 +15,21 @@
     @js($livewire),
     @js($property),
     @js($value),
+    @js($min),
+    @js($max),
     @js($locale))">
     <x-dynamic-component :component="TallStackUi::prefix('input')"
                          {{ $attributes->whereDoesntStartWith('wire:model') }}
                          class="appearance-number-none"
                          inputmode="numeric"
+                         :min="$min"
+                         :max="$max"
                          :$label
                          :$hint
                          :$invalidate
                          :alternative="$property"
                          x-on:input="sync"
+                         x-on:blur="validate()"
                          x-model="input">
         @if ($symbol || $currency || $clearable)
             @if (!empty($symbols['symbol']) && $symbol)

--- a/tests/Browser/Form/CurrencyTest.php
+++ b/tests/Browser/Form/CurrencyTest.php
@@ -216,4 +216,35 @@ class CurrencyTest extends BrowserTestCase
             ->typeSlowly('@input', 'nan')
             ->assertNotVisible('@money');
     }
+
+    #[Test]
+    public function can_validate_min_and_max(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public ?string $money = null;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <p dusk="money">{{ $money }}</p>
+                
+                    <x-currency dusk="input" wire:model.live="money" min="10" max="20" />
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->typeSlowly('@input', '5')
+            ->click('@money')
+            ->assertInputValue('@input', '')
+            ->typeSlowly('@input', '25')
+            ->click('@money')
+            ->assertInputValue('@input', '')
+            ->typeSlowly('@input', '15')
+            ->click('@money')
+            ->assertInputValue('@input', '15.00')
+            ->assertSeeIn('@money', '15.00');
+    }
 }

--- a/tests/Feature/Components/Form/CurrencyTest.php
+++ b/tests/Feature/Components/Form/CurrencyTest.php
@@ -41,3 +41,22 @@ it('can render with different prefix and suffix', function () {
         ->toContain('R$')
         ->toContain('BRL');
 });
+
+it('can render with min and max', function () {
+    $component = <<<'HTML'
+    <x-currency min="10" max="20" />
+    HTML;
+
+    expect($component)->render()
+        ->toContain('min="10"')
+        ->toContain('max="20"');
+});
+
+it('can render with min zero', function () {
+    $component = <<<'HTML'
+    <x-currency min="0" />
+    HTML;
+
+    expect($component)->render()
+        ->toContain('min="0"');
+});


### PR DESCRIPTION
### Checklist:

- [X] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [X] I created a new branch on my fork for this pull request 
- [X] I ensure that the current tests are passing
- [X] I added tests that prove this pull request is working

<!-- WARNING! The pull request may be disapproved 
if you haven't created a new branch on your fork. -->

### What:

<!-- Use a "x" to mark the option that best fits your PR. -->

- [X] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

Introduces min and max attributes to the currency component, enabling configurable value boundaries.

### Demonstration & Notes:

