### PR TITLE
add chunk upload

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[compose.yaml]
+indent_size = 4
+
+[*.js]
+indent_size = 2
+tab_width = 2

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,10 @@
     "blade-ui-kit/blade-icons": "^1.7.0"
   },
   "scripts": {
-    "test": "./vendor/bin/pest",
+    "test": [
+      "Composer\\Config::disableProcessTimeout",
+      "./vendor/bin/pest"
+    ],
     "bench": "vendor/bin/testbench",
     "type": "./vendor/bin/pest --type-coverage",
     "rector": "php ./vendor/bin/rector process --dry-run --config=rector.php",

--- a/js/components/form/upload.js
+++ b/js/components/form/upload.js
@@ -9,7 +9,9 @@ export default (
   placeholder,
   placeholders,
   overflowing,
-  closeAfterUpload
+  closeAfterUpload,
+  chunk,
+  chunkSize
 ) => ({
   show: false,
   uploading: false,
@@ -24,6 +26,8 @@ export default (
   component: null,
   preview: false,
   image: null,
+  chunk: chunk,
+  chunkSize: chunkSize,
   init() {
     this.component = Livewire.find(id).__instance;
 
@@ -58,9 +62,71 @@ export default (
       new CustomEvent('upload', { detail: { files: this.$refs.files.files } })
     );
 
+    if (this.chunk) return this.chunks();
+
     if (this.multiple) return this.multiples();
 
     this.single();
+  },
+  /**
+   * Upload files in chunks.
+   * @returns {void}
+   */
+  async chunks() {
+    const files = this.$refs.files.files;
+    const totalFiles = files.length;
+
+    for (let i = 0; i < totalFiles; i++) {
+      const file = files[i];
+      // Unique identifier for this file upload session
+      const identifier = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+      const totalChunks = Math.ceil(file.size / this.chunkSize);
+
+      for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+        const start = chunkIndex * this.chunkSize;
+        const end = Math.min(start + this.chunkSize, file.size);
+        const chunk = file.slice(start, end);
+
+        const base64 = await this.toBase64(chunk);
+        const data = base64.split(',')[1];
+
+        await this.component.$wire.call('uploadChunk',
+          this.property,
+          identifier,
+          data,
+          chunkIndex,
+          totalChunks
+        );
+
+        this.progress = Math.round(((chunkIndex + 1) / totalChunks) * 100);
+      }
+
+      await this.component.$wire.call('finishChunkUpload',
+        this.property,
+        identifier,
+        file.name,
+        totalChunks,
+        this.multiple
+      );
+    }
+
+    this.uploading = false;
+    this.progress = 0;
+
+    if (closeAfterUpload) this.show = false;
+  },
+  /**
+   * Convert file/blob to Base64.
+   * @param file {Blob}
+   * @returns {Promise<string>}
+   */
+  toBase64(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = error => reject(error);
+    });
   },
   /**
    * Upload multiple files.

--- a/src/Traits/WithChunkUploads.php
+++ b/src/Traits/WithChunkUploads.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace TallStackUi\Traits;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+
+trait WithChunkUploads
+{
+    public function uploadChunk(string $property, string $identifier, string $chunkData, int $chunkIndex, int $totalChunks): void
+    {
+        $disk = Storage::disk(FileUploadConfiguration::disk());
+        $path = 'tallstackui-chunks/' . $identifier;
+
+        if (!$disk->exists($path)) {
+            $disk->makeDirectory($path);
+        }
+
+        $chunk = base64_decode($chunkData);
+        $disk->put($path . '/' . $chunkIndex . '.part', $chunk);
+    }
+
+    public function finishChunkUpload(string $property, string $identifier, string $filename, int $totalChunks, bool $isMultiple = false): void
+    {
+        $disk = Storage::disk(FileUploadConfiguration::disk());
+        $path = 'tallstackui-chunks/' . $identifier;
+
+        $tempPath = tempnam(sys_get_temp_dir(), 'tsui_upload_');
+        $handle = fopen($tempPath, 'wb');
+
+        for ($i = 0; $i < $totalChunks; $i++) {
+            $chunkPath = $path . '/' . $i . '.part';
+            if ($disk->exists($chunkPath)) {
+                fwrite($handle, $disk->get($chunkPath));
+            }
+        }
+
+        fclose($handle);
+
+        $file = new UploadedFile($tempPath, $filename, null, null, true);
+
+        // This stores the file in Livewire's temporary directory and returns the path
+        $storePath = $file->store(FileUploadConfiguration::path(), FileUploadConfiguration::disk());
+
+        // We need to create the metadata file for Livewire to be able to
+        // retrieve the original file name and other information.
+        $disk->put($storePath . '.json', json_encode([
+            'name' => $filename,
+            'size' => $file->getSize(),
+            'type' => $file->getMimeType(),
+        ]));
+
+        // Create TemporaryUploadedFile instance
+        // createFromLivewire expects the file name, not the full path,
+        // because it prepends the directory using FileUploadConfiguration::path()
+        $temporaryFile = TemporaryUploadedFile::createFromLivewire(basename($storePath));
+
+        // Cleanup chunks and temp file
+        $disk->deleteDirectory($path);
+        @unlink($tempPath);
+
+        // Assign to property
+        if ($isMultiple) {
+            $current = $this->getPropertyValue($property);
+
+            if (!is_array($current)) {
+                $current = $current ? [$current] : [];
+            }
+
+            $current[] = $temporaryFile;
+            $this->fill([$property => $current]);
+        } else {
+            $this->fill([$property => $temporaryFile]);
+        }
+
+        // Trigger validation if needed
+        // $this->validateOnly($property); // Optional, might be handled by user
+    }
+}

--- a/src/View/Components/Form/Upload.php
+++ b/src/View/Components/Form/Upload.php
@@ -35,6 +35,7 @@ class Upload extends TallStackUiComponent implements Personalization
         public ?ComponentSlot $footer = null,
         public ?bool $overflow = null,
         public ?bool $closeAfterUpload = null,
+        public ?bool $chunk = false,
     ) {
         $this->placeholder ??= trans('tallstack-ui::messages.upload.placeholder');
         $this->error ??= trans('tallstack-ui::messages.upload.error');

--- a/src/config.php
+++ b/src/config.php
@@ -222,6 +222,9 @@ return [
                     'unfiltered' => false,
                 ],
             ],
+            'upload' => [
+                'chunk' => 1024 * 1024 * 2, // 2MB
+            ],
         ],
 
         /*

--- a/src/resources/views/components/form/upload.blade.php
+++ b/src/resources/views/components/form/upload.blade.php
@@ -1,191 +1,147 @@
 @php
-    $personalize = $classes();
+  $personalize = $classes();
 @endphp
 
-<div x-data="tallstackui_formUpload(
-        @js($this->getId()),
-        @js($property),
-        @js($multiple),
-        @js($error),
-        @js($static),
-        @js($placeholder),
-        @js(trans('tallstack-ui::messages.upload.uploaded')),
-        @js($overflow),
-        @js($closeAfterUpload))"
-     x-cloak
-     x-on:livewire-upload-start="uploading = true"
-     x-on:livewire-upload-finish="uploading = false"
-     x-on:livewire-upload-error="uploading = false"
-     x-on:livewire-upload-progress="progress = $event.detail.progress"
-     class="relative" x-on:click.outside="show = false">
-     @if ($static) <p hidden x-ref="placeholder">{{ $placeholder }}</p> @endif
-        <x-dynamic-component :component="TallStackUi::prefix('input')"
-                             :value="$placeholder"
-                             :$hint
-                             x-on:click="show = !show"
-                             x-ref="input"
-                             class="cursor-pointer caret-transparent"
-                             x-on:keydown="$event.preventDefault()"
-                             spellcheck="false"
-                             dusk="tallstackui_upload_input"
-                             invalidate
-                             floatable>
-                             <x-slot:suffix class="ml-1 mr-2">
-                                <button type="button" class="cursor-pointer" x-on:click="show = !show">
-                                    <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                                                         :icon="TallStackUi::icon('arrow-up-tray')"
-                                                         internal
-                                                         class="{{ $personalize['icon'] }}" />
-                                </button>
-                             </x-slot:suffix>
-            <x-slot:label>
-                @if ($label)
-                    <x-dynamic-component :component="TallStackUi::prefix('label')"
-                                         :$id
-                                         :$label
-                                         x-on:click="$event.preventDefault()"
-                                         :error="$errors->has($property)" />
-                @endif
-            </x-slot:label>
-        </x-dynamic-component>
-         @if ($invalid['status'])
-            <span class="{{ $personalize['invalid'] }}">
-                {{ trans('tallstack-ui::messages.upload.invalid') }}
-            </span>
-         @endif
-    @if ($preview)
-        <template x-teleport="body">
-            <div x-show="preview"
-                 x-on:click="preview = false; $nextTick(() => show = true)"
-                 x-transition:enter="ease-out duration-300"
-                 x-transition:enter-start="opacity-0"
-                 x-transition:enter-end="opacity-100"
-                 x-transition:leave="ease-in duration-200"
-                 x-transition:leave-start="opacity-100"
-                 x-transition:leave-end="opacity-0"
-                 class="{{ $personalize['preview.backdrop'] }}"
-                 dusk="tallstackui_file_preview_backdrop">
-                    <div class="{{ $personalize['preview.wrapper'] }}">
-                        <button class="{{ $personalize['preview.button.base'] }}" x-on:click="preview = false; $nextTick(() => show = true)">
-                            <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                                                 :icon="TallStackUi::icon('x-mark')"
-                                                 class="{{ $personalize['preview.button.icon'] }}"
-                                                 internal />
-                        </button>
-                        <img x-bind:src="image" class="{{ $personalize['preview.image'] }}">
-                    </div>
-            </div>
-        </template>
+<div class="relative" x-cloak x-data="tallstackui_formUpload(
+    @js($this->getId()),
+    @js($property),
+    @js($multiple),
+    @js($error),
+    @js($static),
+    @js($placeholder),
+    @js(trans('tallstack-ui::messages.upload.uploaded')),
+    @js($overflow),
+    @js($closeAfterUpload),
+    @js($chunk ?? false),
+    @js(config('tallstackui.settings.form.upload.chunk', 1048576)))" x-on:click.outside="show = false" x-on:livewire-upload-error="uploading = false"
+  x-on:livewire-upload-finish="uploading = false" x-on:livewire-upload-progress="progress = $event.detail.progress" x-on:livewire-upload-start="uploading = true">
+  @if ($static)
+    <p hidden x-ref="placeholder">{{ $placeholder }}</p>
+  @endif
+  <x-dynamic-component :$hint :component="TallStackUi::prefix('input')" :value="$placeholder" class="cursor-pointer caret-transparent" dusk="tallstackui_upload_input" floatable invalidate
+    spellcheck="false" x-on:click="show = !show" x-on:keydown="$event.preventDefault()" x-ref="input">
+    <x-slot:suffix class="ml-1 mr-2">
+      <button class="cursor-pointer" type="button" x-on:click="show = !show">
+        <x-dynamic-component :component="TallStackUi::prefix('icon')" :icon="TallStackUi::icon('arrow-up-tray')" class="{{ $personalize['icon'] }}" internal />
+      </button>
+    </x-slot:suffix>
+    <x-slot:label>
+      @if ($label)
+        <x-dynamic-component :$id :$label :component="TallStackUi::prefix('label')" :error="$errors->has($property)" x-on:click="$event.preventDefault()" />
+      @endif
+    </x-slot:label>
+  </x-dynamic-component>
+  @if ($invalid['status'])
+    <span class="{{ $personalize['invalid'] }}">
+      {{ trans('tallstack-ui::messages.upload.invalid') }}
+    </span>
+  @endif
+  @if ($preview)
+    <template x-teleport="body">
+      <div class="{{ $personalize['preview.backdrop'] }}" dusk="tallstackui_file_preview_backdrop" x-on:click="preview = false; $nextTick(() => show = true)"
+        x-show="preview" x-transition:enter-end="opacity-100" x-transition:enter-start="opacity-0" x-transition:enter="ease-out duration-300"
+        x-transition:leave-end="opacity-0" x-transition:leave-start="opacity-100" x-transition:leave="ease-in duration-200">
+        <div class="{{ $personalize['preview.wrapper'] }}">
+          <button class="{{ $personalize['preview.button.base'] }}" x-on:click="preview = false; $nextTick(() => show = true)">
+            <x-dynamic-component :component="TallStackUi::prefix('icon')" :icon="TallStackUi::icon('x-mark')" class="{{ $personalize['preview.button.icon'] }}" internal />
+          </button>
+          <img class="{{ $personalize['preview.image'] }}" x-bind:src="image">
+        </div>
+      </div>
+    </template>
+  @endif
+  <x-dynamic-component :class="$personalize['floating.class']" :component="TallStackUi::prefix('floating')" :floating="$personalize['floating.default']" dusk="tallstackui_upload_floating">
+    @if (!$static)
+      <div @class([
+          'flex flex-col w-full items-center justify-center',
+          'mb-2' => $footer?->isNotEmpty(),
+      ])>
+        <div :class="{ 'bg-primary-100': dragging }" class="{{ $personalize['placeholder.wrapper'] }}">
+          <div class="{{ $personalize['placeholder.icon.wrapper'] }}">
+            <x-dynamic-component :component="TallStackUi::prefix('icon')" :icon="TallStackUi::icon('cloud-arrow-up')" class="{{ $personalize['placeholder.icon.class'] }}" internal />
+            <p class="{{ $personalize['placeholder.title'] }}">
+              {{ trans('tallstack-ui::messages.upload.upload') }}
+            </p>
+          </div>
+          @if (is_string($tip))
+            <p class="{{ $personalize['placeholder.tip'] }}">{{ $tip }}</p>
+          @else
+            {{ $tip }}
+          @endif
+          <input {{ $attributes->only(['accept', 'x-on:upload']) }} @if ($multiple) multiple @endif
+            @if (!app()->runningUnitTests()) class="{{ $personalize['placeholder.input'] }}" @endif dusk="tallstackui_file_select" id="{{ $property }}"
+            type="file" x-on:change="upload()" x-on:dragleave="dragging = false" x-on:dragover="dragging = true" x-on:drop="dragging = false;"
+            x-ref="files" />
+        </div>
+      </div>
     @endif
-     <x-dynamic-component :component="TallStackUi::prefix('floating')"
-                          :floating="$personalize['floating.default']"
-                          :class="$personalize['floating.class']"
-                          dusk="tallstackui_upload_floating">
-         @if (!$static)
-         <div @class(['flex flex-col w-full items-center justify-center', 'mb-2' => $footer?->isNotEmpty()])>
-             <div class="{{ $personalize['placeholder.wrapper'] }}" :class="{ 'bg-primary-100': dragging }">
-                 <div class="{{ $personalize['placeholder.icon.wrapper'] }}">
-                     <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                                          :icon="TallStackUi::icon('cloud-arrow-up')"
-                                          internal
-                                          class="{{ $personalize['placeholder.icon.class'] }}" />
-                     <p class="{{ $personalize['placeholder.title'] }}">
-                         {{ trans('tallstack-ui::messages.upload.upload') }}
-                     </p>
-                 </div>
-                 @if (is_string($tip))
-                     <p class="{{ $personalize['placeholder.tip'] }}">{{ $tip }}</p>
-                 @else
-                     {{ $tip }}
-                 @endif
-                 <input id="{{ $property }}"
-                        type="file"
-                        dusk="tallstackui_file_select"
-                        @if (!app()->runningUnitTests()) class="{{ $personalize['placeholder.input'] }}" @endif
-                        x-ref="files"
-                        {{ $attributes->only(['accept', 'x-on:upload']) }}
-                        x-on:change="upload()"
-                        x-on:dragover="dragging = true"
-                        x-on:dragleave="dragging = false"
-                        x-on:drop="dragging = false;"
-                        @if ($multiple) multiple @endif />
-             </div>
-         </div>
-         @endif
-         <div @class([$personalize['error.wrapper'], 'mb-2' => $footer?->isNotEmpty()]) x-show="@js($error) && error">
-             <p class="{{ $personalize['error.message'] }}" x-text="warning"></p>
-         </div>
-         <div x-show="uploading"
-              role="progressbar"
-              @class([$personalize['upload.wrapper'], 'mb-2' => $footer?->isNotEmpty()])>
-             <div class="{{ $personalize['upload.progress'] }}" x-bind:style="'width: ' + progress + '%'"></div>
-         </div>
-         @if ($value)
-             <div class="{{ $personalize['item.wrapper'] }}" x-ref="items">
-                 <ul role="list" class="{{ $personalize['item.ul'] }}">
-                     @foreach($adapter($value) as $key => $file)
-                         <li @class([$personalize['item.li'], 'py-2' => is_array($value) && count($value) > 1])>
-                             <div class="flex min-w-0 gap-x-4">
-                                 @if ($file['is_image'])
-                                 <img src="{{ $file['url'] }}"
-                                      dusk="tallstackui_file_preview"
-                                      @if ($preview) x-on:click="image = @js($file['url']); preview = true; show = false" @endif
-                                      @class([$personalize['item.image'], 'cursor-pointer' => $preview])>
-                                 @else
-                                     <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                                                          :icon="TallStackUi::icon('document-text')"
-                                                          internal
-                                                          :class="$personalize['item.document']" />
-                                 @endif
-                                 <div class="flex-auto min-w-0">
-                                     <p class="{{ $personalize['item.title'] }}">{{ $file['real_name'] }}</p>
-                                     <x-dynamic-component :component="TallStackUi::prefix('error')"
-                                                          :property="is_array($value) ? $property . '.' . $key : $property" />
-                                     @if ($file['size'] !== null)
-                                         <p class="{{ $personalize['item.size'] }}">
-                                             <span>{{ trans('tallstack-ui::messages.upload.size') }}: </span>
-                                             <span>{{ $file['size'] }}</span>
-                                         </p>
-                                     @endif
-                                 </div>
-                             </div>
-                             <div class="flex flex-col items-end shrink-0">
-                                 @if ($delete)
-                                     <button type="button"
-                                             class="cursor-pointer"
-                                             {{ $attributes->only('x-on:remove') }}
-                                             x-on:click="remove(@js($deleteMethod), @js($file))">
-                                         <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                                                              :icon="TallStackUi::icon('trash')"
-                                                              class="{{ $personalize['item.delete'] }}"
-                                                              internal />
-                                     </button>
-                                 @endif
-                             </div>
-                         </li>
-                     @endforeach
-                 </ul>
-             </div>
-         @elseif ($static === true)
-             <div class="{{ $personalize['static.empty.wrapper'] }}">
-                 <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                                      :icon="TallStackUi::icon('photo')"
-                                      internal
-                                      class="{{ $personalize['static.empty.icon'] }}" />
-                 <h3 class="{{ $personalize['static.empty.title'] }}">
-                     {{ trans('tallstack-ui::messages.upload.static.empty.title') }}
-                 </h3>
-                 <p class="{{ $personalize['static.empty.description'] }}">
-                     {{ trans('tallstack-ui::messages.upload.static.empty.description') }}
-                 </p>
-             </div>
-         @endif
-         @if ($footer?->isNotEmpty())
-             @unless ($footer->attributes->has('when-uploaded') && !$value)
-                 <x-slot:footer>
-                     {{ $footer }}
-                 </x-slot:footer>
-             @endunless
-         @endif
-     </x-dynamic-component>
+    <div @class([
+        $personalize['error.wrapper'],
+        'mb-2' => $footer?->isNotEmpty(),
+    ]) x-show="@js($error) && error">
+      <p class="{{ $personalize['error.message'] }}" x-text="warning"></p>
+    </div>
+    <div @class([
+        $personalize['upload.wrapper'],
+        'mb-2' => $footer?->isNotEmpty(),
+    ]) role="progressbar" x-show="uploading">
+      <div class="{{ $personalize['upload.progress'] }}" x-bind:style="'width: ' + progress + '%'"></div>
+    </div>
+    @if ($value)
+      <div class="{{ $personalize['item.wrapper'] }}" x-ref="items">
+        <ul class="{{ $personalize['item.ul'] }}" role="list">
+          @foreach ($adapter($value) as $key => $file)
+            <li @class([
+                $personalize['item.li'],
+                'py-2' => is_array($value) && count($value) > 1,
+            ])>
+              <div class="flex min-w-0 gap-x-4">
+                @if ($file['is_image'])
+                  <img @if ($preview) x-on:click="image = @js($file['url']); preview = true; show = false" @endif
+                    @class([$personalize['item.image'], 'cursor-pointer' => $preview]) dusk="tallstackui_file_preview" src="{{ $file['url'] }}">
+                @else
+                  <x-dynamic-component :class="$personalize['item.document']" :component="TallStackUi::prefix('icon')" :icon="TallStackUi::icon('document-text')" internal />
+                @endif
+                <div class="min-w-0 flex-auto">
+                  <p class="{{ $personalize['item.title'] }}">{{ $file['real_name'] }}</p>
+                  <x-dynamic-component :component="TallStackUi::prefix('error')" :property="is_array($value) ? $property . '.' . $key : $property" />
+                  @if ($file['size'] !== null)
+                    <p class="{{ $personalize['item.size'] }}">
+                      <span>{{ trans('tallstack-ui::messages.upload.size') }}: </span>
+                      <span>{{ $file['size'] }}</span>
+                    </p>
+                  @endif
+                </div>
+              </div>
+              <div class="flex shrink-0 flex-col items-end">
+                @if ($delete)
+                  <button {{ $attributes->only('x-on:remove') }} class="cursor-pointer" type="button"
+                    x-on:click="remove(@js($deleteMethod), @js($file))">
+                    <x-dynamic-component :component="TallStackUi::prefix('icon')" :icon="TallStackUi::icon('trash')" class="{{ $personalize['item.delete'] }}" internal />
+                  </button>
+                @endif
+              </div>
+            </li>
+          @endforeach
+        </ul>
+      </div>
+    @elseif ($static === true)
+      <div class="{{ $personalize['static.empty.wrapper'] }}">
+        <x-dynamic-component :component="TallStackUi::prefix('icon')" :icon="TallStackUi::icon('photo')" class="{{ $personalize['static.empty.icon'] }}" internal />
+        <h3 class="{{ $personalize['static.empty.title'] }}">
+          {{ trans('tallstack-ui::messages.upload.static.empty.title') }}
+        </h3>
+        <p class="{{ $personalize['static.empty.description'] }}">
+          {{ trans('tallstack-ui::messages.upload.static.empty.description') }}
+        </p>
+      </div>
+    @endif
+    @if ($footer?->isNotEmpty())
+      @unless ($footer->attributes->has('when-uploaded') && !$value)
+        <x-slot:footer>
+          {{ $footer }}
+        </x-slot:footer>
+      @endunless
+    @endif
+  </x-dynamic-component>
 </div>

--- a/tests/Browser/Form/UploadTest.php
+++ b/tests/Browser/Form/UploadTest.php
@@ -13,6 +13,7 @@ use Livewire\Livewire;
 use Livewire\WithFileUploads;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Finder\SplFileInfo;
+use TallStackUi\Traits\WithChunkUploads;
 use Tests\Browser\BrowserTestCase;
 
 class UploadTest extends BrowserTestCase
@@ -33,7 +34,7 @@ class UploadTest extends BrowserTestCase
                     @if ($photo)
                         <p dusk="uploaded">{{ $photo->getClientOriginalName() }}</p>
                     @endif
-                    
+
                     <x-upload label="Document" wire:model.live="photo" close-after-upload />
                 </div>
                 HTML;
@@ -43,7 +44,7 @@ class UploadTest extends BrowserTestCase
             ->assertMissing('@uploaded')
             ->click('@tallstackui_upload_input')
             ->waitForText('Click here to upload')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
             ->waitForTextIn('@uploaded', 'test.jpeg')
             ->assertSeeIn('@uploaded', 'test.jpeg')
             ->assertNotVisible('@tallstackui_upload_floating');
@@ -56,7 +57,7 @@ class UploadTest extends BrowserTestCase
 
         File::ensureDirectoryExists(storage_path('app/public/test'));
 
-        File::copy(__DIR__.'/../../Fixtures/test.jpeg', public_path('storage/test/test.jpeg'));
+        File::copy(__DIR__ . '/../../Fixtures/test.jpeg', public_path('storage/test/test.jpeg'));
 
         $this->assertTrue(File::exists(public_path('storage/test/test.jpeg')));
 
@@ -68,12 +69,12 @@ class UploadTest extends BrowserTestCase
 
             public function mount(): void
             {
-                $this->photo = collect(File::allFiles(public_path('storage/test')))->map(fn (SplFileInfo $file) => [
+                $this->photo = collect(File::allFiles(public_path('storage/test')))->map(fn(SplFileInfo $file) => [
                     'name' => $file->getFilename(),
                     'extension' => $file->getExtension(),
                     'size' => $file->getSize(),
                     'path' => $file->getPathname(),
-                    'url' => Storage::url('public/test/'.$file->getFilename()),
+                    'url' => Storage::url('public/test/' . $file->getFilename()),
                 ])->toArray();
             }
 
@@ -81,9 +82,9 @@ class UploadTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>
-                    <x-upload label="Document" 
-                              wire:model.live="photo" 
-                              static 
+                    <x-upload label="Document"
+                              wire:model.live="photo"
+                              static
                               delete />
                 </div>
                 HTML;
@@ -99,7 +100,7 @@ class UploadTest extends BrowserTestCase
 
                 $files = Arr::wrap($this->photo);
 
-                $collect = collect($files)->filter(fn (array $item) => $item['name'] !== $content['real_name']);
+                $collect = collect($files)->filter(fn(array $item) => $item['name'] !== $content['real_name']);
 
                 $this->photo = $collect->toArray();
             }
@@ -137,7 +138,7 @@ class UploadTest extends BrowserTestCase
                     @if ($photo)
                         <p dusk="uploaded">{{ $photo->getClientOriginalName() }}</p>
                     @endif
-                    
+
                     <x-upload label="Document" wire:model.live="photo" delete />
                 </div>
                 HTML;
@@ -152,11 +153,11 @@ class UploadTest extends BrowserTestCase
                 $files = Arr::wrap($this->photo);
 
                 /** @var UploadedFile $file */
-                $file = collect($files)->filter(fn (UploadedFile $item) => $item->getFilename() === $content['temporary_name'])->first();
+                $file = collect($files)->filter(fn(UploadedFile $item) => $item->getFilename() === $content['temporary_name'])->first();
 
-                rescue(fn () => $file->delete(), report: false); // @phpstan-ignore-line
+                rescue(fn() => $file->delete(), report: false); // @phpstan-ignore-line
 
-                $collect = collect($files)->filter(fn (UploadedFile $item) => $item->getFilename() !== $content['temporary_name']);
+                $collect = collect($files)->filter(fn(UploadedFile $item) => $item->getFilename() !== $content['temporary_name']);
 
                 $this->photo = is_array($this->photo) ? $collect->toArray() : $collect->first();
             }
@@ -165,7 +166,7 @@ class UploadTest extends BrowserTestCase
             ->assertMissing('@uploaded')
             ->click('@tallstackui_upload_input')
             ->waitForText('Click here to upload')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
             ->waitForTextIn('@uploaded', 'test.jpeg')
             ->assertSeeIn('@uploaded', 'test.jpeg')
             ->waitForLivewire()
@@ -189,7 +190,7 @@ class UploadTest extends BrowserTestCase
                     @if ($photo)
                         <p dusk="uploaded">{{ $photo->getClientOriginalName() }}</p>
                     @endif
-                    
+
                     <x-upload label="Document" wire:model.live="photo" delete delete-method="fooBar" />
                 </div>
                 HTML;
@@ -204,11 +205,11 @@ class UploadTest extends BrowserTestCase
                 $files = Arr::wrap($this->photo);
 
                 /** @var UploadedFile $file */
-                $file = collect($files)->filter(fn (UploadedFile $item) => $item->getFilename() === $content['temporary_name'])->first();
+                $file = collect($files)->filter(fn(UploadedFile $item) => $item->getFilename() === $content['temporary_name'])->first();
 
-                rescue(fn () => $file->delete(), report: false); // @phpstan-ignore-line
+                rescue(fn() => $file->delete(), report: false); // @phpstan-ignore-line
 
-                $collect = collect($files)->filter(fn (UploadedFile $item) => $item->getFilename() !== $content['temporary_name']);
+                $collect = collect($files)->filter(fn(UploadedFile $item) => $item->getFilename() !== $content['temporary_name']);
 
                 $this->photo = is_array($this->photo) ? $collect->toArray() : $collect->first();
             }
@@ -217,7 +218,7 @@ class UploadTest extends BrowserTestCase
             ->assertMissing('@uploaded')
             ->click('@tallstackui_upload_input')
             ->waitForText('Click here to upload')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
             ->waitForTextIn('@uploaded', 'test.jpeg')
             ->assertSeeIn('@uploaded', 'test.jpeg')
             ->waitForLivewire()
@@ -237,7 +238,7 @@ class UploadTest extends BrowserTestCase
             public function render(): string
             {
                 return <<<'HTML'
-                <div>                    
+                <div>
                     <x-upload label="Document" wire:model="photo">
                         <x-slot:footer when-uploaded>
                             Foo Bar Baz
@@ -253,7 +254,7 @@ class UploadTest extends BrowserTestCase
             ->waitForText('Click here to upload')
             ->waitUntilMissingText('Foo Bar Baz')
             ->assertDontSee('Foo Bar Baz')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
             ->waitForText('Foo Bar Baz')
             ->assertSee('Foo Bar Baz');
     }
@@ -270,7 +271,7 @@ class UploadTest extends BrowserTestCase
             public function render(): string
             {
                 return <<<'HTML'
-                <div>                    
+                <div>
                     <x-upload label="Document" wire:model="photo" static />
                 </div>
                 HTML;
@@ -296,7 +297,7 @@ class UploadTest extends BrowserTestCase
             public function render(): string
             {
                 return <<<'HTML'
-                <div>                    
+                <div>
                     <x-upload label="Document" wire:model="photo">
                         <x-slot:footer>
                             Foo Bar Baz
@@ -331,7 +332,7 @@ class UploadTest extends BrowserTestCase
                     @if ($photo)
                         <p dusk="uploaded">{{ $photo->getClientOriginalName() }}</p>
                     @endif
-                    
+
                     <x-upload label="Document" wire:model.live="photo" />
                 </div>
                 HTML;
@@ -341,7 +342,7 @@ class UploadTest extends BrowserTestCase
             ->assertMissing('@uploaded')
             ->click('@tallstackui_upload_input')
             ->waitForText('Click here to upload')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
             ->waitForTextIn('@uploaded', 'test.jpeg')
             ->assertSeeIn('@uploaded', 'test.jpeg')
             ->click('@tallstackui_file_preview')
@@ -356,7 +357,7 @@ class UploadTest extends BrowserTestCase
 
         File::ensureDirectoryExists(storage_path('app/public/test'));
 
-        File::copy(__DIR__.'/../../Fixtures/test.jpeg', public_path('storage/test/test.jpeg'));
+        File::copy(__DIR__ . '/../../Fixtures/test.jpeg', public_path('storage/test/test.jpeg'));
 
         $this->assertTrue(File::exists(public_path('storage/test/test.jpeg')));
 
@@ -368,12 +369,12 @@ class UploadTest extends BrowserTestCase
 
             public function mount(): void
             {
-                $this->photo = collect(File::allFiles(public_path('storage/test')))->map(fn (SplFileInfo $file) => [
+                $this->photo = collect(File::allFiles(public_path('storage/test')))->map(fn(SplFileInfo $file) => [
                     'name' => $file->getFilename(),
                     'extension' => $file->getExtension(),
                     'size' => $file->getSize(),
                     'path' => $file->getPathname(),
-                    'url' => Storage::url('public/test/'.$file->getFilename()),
+                    'url' => Storage::url('public/test/' . $file->getFilename()),
                 ])->toArray();
             }
 
@@ -381,8 +382,8 @@ class UploadTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>
-                    <x-upload label="Document" 
-                              wire:model.live="photo" 
+                    <x-upload label="Document"
+                              wire:model.live="photo"
                               static />
                 </div>
                 HTML;
@@ -411,7 +412,7 @@ class UploadTest extends BrowserTestCase
             public function render(): string
             {
                 return <<<'HTML'
-                <div>                    
+                <div>
                     <x-upload label="Document" tip="Accept pdf or png" wire:model="photo" />
                 </div>
                 HTML;
@@ -442,7 +443,7 @@ class UploadTest extends BrowserTestCase
                     @if ($photo)
                         <p dusk="uploaded">{{ $photo->getClientOriginalName() }}</p>
                     @endif
-                    
+
                     <x-upload label="Document" wire:model.live="photo" />
                     <button dusk="save" wire:click="save">Save</button>
                 </div>
@@ -465,7 +466,7 @@ class UploadTest extends BrowserTestCase
             ->assertMissing('@uploaded')
             ->click('@tallstackui_upload_input')
             ->waitForText('Click here to upload')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
             ->click('@tallstackui_upload_input')
             ->pause(100)
             ->click('@save')
@@ -512,7 +513,7 @@ class UploadTest extends BrowserTestCase
                             <p dusk="uploaded-1">{{ $photos[1]->getClientOriginalName() }}</p>
                         @endif
                     @endif
-                    
+
                     <x-upload label="Document" wire:model="photos" multiple />
                 </div>
                 HTML;
@@ -535,7 +536,7 @@ class UploadTest extends BrowserTestCase
 
                 $file = Arr::flatten(array_merge($this->saved, [$this->photos]));
 
-                $this->photos = collect($file)->unique(fn (UploadedFile $item) => $item->getClientOriginalName())->toArray();
+                $this->photos = collect($file)->unique(fn(UploadedFile $item) => $item->getClientOriginalName())->toArray();
 
                 // This is only necessary in tests, to make sure
                 // the order of the files is always the same
@@ -552,8 +553,8 @@ class UploadTest extends BrowserTestCase
             ->assertMissing('@uploaded-1')
             ->click('@tallstackui_upload_input')
             ->waitForText('Click here to upload')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.pdf')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.pdf')
             // This is necessary because Livewire always send
             // request to the backend when file is uploaded
             ->waitForTextIn('@upload-finish', 'Uploaded')
@@ -579,7 +580,7 @@ class UploadTest extends BrowserTestCase
                     @if ($photo)
                         <p dusk="uploaded">{{ $photo->getClientOriginalName() }}</p>
                     @endif
-                    
+
                     <x-upload label="Document" wire:model.live="photo" />
                 </div>
                 HTML;
@@ -589,7 +590,7 @@ class UploadTest extends BrowserTestCase
             ->assertMissing('@uploaded')
             ->click('@tallstackui_upload_input')
             ->waitForText('Click here to upload')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
             ->waitForTextIn('@uploaded', 'test.jpeg')
             ->assertSeeIn('@uploaded', 'test.jpeg');
     }
@@ -610,7 +611,7 @@ class UploadTest extends BrowserTestCase
                     @if ($form)
                         <p dusk="uploaded">{{ $form->photo?->getClientOriginalName() }}</p>
                     @endif
-                    
+
                     <x-upload label="Document" wire:model.live="form.photo" />
                 </div>
                 HTML;
@@ -620,7 +621,7 @@ class UploadTest extends BrowserTestCase
             ->assertMissing('@uploaded')
             ->click('@tallstackui_upload_input')
             ->waitForText('Click here to upload')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
             ->waitForTextIn('@uploaded', 'test.jpeg')
             ->assertSeeIn('@uploaded', 'test.jpeg');
     }
@@ -632,7 +633,7 @@ class UploadTest extends BrowserTestCase
 
         File::ensureDirectoryExists(storage_path('app/public/test'));
 
-        File::copy(__DIR__.'/../../Fixtures/test.jpeg', public_path('storage/test/test.jpeg'));
+        File::copy(__DIR__ . '/../../Fixtures/test.jpeg', public_path('storage/test/test.jpeg'));
 
         $this->assertTrue(File::exists(public_path('storage/test/test.jpeg')));
 
@@ -644,12 +645,12 @@ class UploadTest extends BrowserTestCase
 
             public function mount(): void
             {
-                $this->photo = collect(File::allFiles(public_path('storage/test')))->map(fn (SplFileInfo $file) => [
+                $this->photo = collect(File::allFiles(public_path('storage/test')))->map(fn(SplFileInfo $file) => [
                     'name' => $file->getFilename(),
                     'extension' => $file->getExtension(),
                     'size' => $file->getSize(),
                     'path' => $file->getPath(),
-                    'url' => Storage::url('test/'.$file->getFilename()),
+                    'url' => Storage::url('test/' . $file->getFilename()),
                 ])->toArray();
             }
 
@@ -657,8 +658,8 @@ class UploadTest extends BrowserTestCase
             {
                 return <<<'HTML'
                 <div>
-                    <x-upload label="Document" 
-                              wire:model.live="photo" 
+                    <x-upload label="Document"
+                              wire:model.live="photo"
                               static />
                 </div>
                 HTML;
@@ -691,12 +692,12 @@ class UploadTest extends BrowserTestCase
                     @if ($removed)
                         <p dusk="remove">{{ $removed }}</p>
                     @endif
-                
+
                     @if ($photo)
                         <p dusk="uploaded">{{ $photo->getClientOriginalName() }}</p>
                     @endif
-                    
-                    <x-upload label="Document" 
+
+                    <x-upload label="Document"
                               wire:model.live="photo"
                               x-on:remove="$wire.set('removed', 'Remove')"
                               delete />
@@ -713,11 +714,11 @@ class UploadTest extends BrowserTestCase
                 $files = Arr::wrap($this->photo);
 
                 /** @var UploadedFile $file */
-                $file = collect($files)->filter(fn (UploadedFile $item) => $item->getFilename() === $content['temporary_name'])->first();
+                $file = collect($files)->filter(fn(UploadedFile $item) => $item->getFilename() === $content['temporary_name'])->first();
 
-                rescue(fn () => $file->delete(), report: false); // @phpstan-ignore-line
+                rescue(fn() => $file->delete(), report: false); // @phpstan-ignore-line
 
-                $collect = collect($files)->filter(fn (UploadedFile $item) => $item->getFilename() !== $content['temporary_name']);
+                $collect = collect($files)->filter(fn(UploadedFile $item) => $item->getFilename() !== $content['temporary_name']);
 
                 $this->photo = is_array($this->photo) ? $collect->toArray() : $collect->first();
             }
@@ -726,7 +727,7 @@ class UploadTest extends BrowserTestCase
             ->assertMissing('@uploaded')
             ->click('@tallstackui_upload_input')
             ->waitForText('Click here to upload')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
             ->waitForTextIn('@uploaded', 'test.jpeg')
             ->assertSeeIn('@uploaded', 'test.jpeg')
             ->waitForLivewire()
@@ -755,13 +756,13 @@ class UploadTest extends BrowserTestCase
                     @if ($uploaded)
                         <p dusk="upload">{{ $uploaded }}</p>
                     @endif
-                    
+
                     @if ($photo)
                         <p dusk="uploaded">{{ $photo->getClientOriginalName() }}</p>
                     @endif
-                    
-                    <x-upload label="Document" 
-                              wire:model.live="photo" 
+
+                    <x-upload label="Document"
+                              wire:model.live="photo"
                               x-on:upload="$wire.set('uploaded', 'Upload')" />
                 </div>
                 HTML;
@@ -771,12 +772,44 @@ class UploadTest extends BrowserTestCase
             ->assertMissing('@uploaded')
             ->click('@tallstackui_upload_input')
             ->waitForText('Click here to upload')
-            ->attach('@tallstackui_file_select', __DIR__.'/../../Fixtures/test.jpeg')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
             ->waitForTextIn('@uploaded', 'test.jpeg')
             ->assertSeeIn('@uploaded', 'test.jpeg')
             ->assertVisible('@upload')
             ->waitForTextIn('@upload', 'Upload')
             ->assertSeeIn('@upload', 'Upload');
+    }
+
+    #[Test]
+    public function can_upload_single_file_in_chunks(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            use WithFileUploads;
+            use WithChunkUploads;
+
+            public $photo;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    @if ($photo)
+                        <p dusk="uploaded">{{ $photo->getClientOriginalName() }}</p>
+                    @endif
+
+                    <x-upload label="Document" wire:model.live="photo" chunk />
+                </div>
+                HTML;
+            }
+        })
+            ->assertSee('Document')
+            ->assertMissing('@uploaded')
+            ->click('@tallstackui_upload_input')
+            ->waitForText('Click here to upload')
+            ->attach('@tallstackui_file_select', __DIR__ . '/../../Fixtures/test.jpeg')
+            ->waitForTextIn('@uploaded', 'test.jpeg')
+            ->assertSeeIn('@uploaded', 'test.jpeg');
     }
 }
 


### PR DESCRIPTION
## Support for Chunked File Uploads
This PR introduces support for **chunked file uploads**, allowing large files to be processed in smaller parts to bypass server-side limits like `post_max_size` and `upload_max_filesize`.

**Features:**

- Seamless integration with Livewire's [TemporaryUploadedFile].
- Support for **single** and **multiple** file uploads.
- Configurable chunk size.
- Proper metadata generation ensuring **correct filename and size** usage.
- Secure implementation preventing access to files outside temporary directories.

**Usage:**

1. Add the `WithChunkUploads` trait to your Livewire component:

```php
use Livewire\Component;
use Livewire\WithFileUploads;
use TallStackUi\Traits\WithChunkUploads;

class MyComponent extends Component
{
    use WithFileUploads;
    use WithChunkUploads; // [!code ++]
    public $files = [];
}