### PR TITLE
Fix null array offset deprecation when blur is not set

### DIFF
--- a/src/resources/views/components/command-palette/main.blade.php
+++ b/src/resources/views/components/command-palette/main.blade.php
@@ -16,7 +16,7 @@
              x-transition:leave-start="opacity-100"
              x-transition:leave-end="opacity-0"
          @endif
-         @class([$customization['backdrop'], $configurations['zIndex'], $customization['blur.'.($configurations['blur'] === true ? 'sm' : $configurations['blur'])] ?? null => $configurations['blur']])></div>
+         @class([$customization['backdrop'], $configurations['zIndex'], ($configurations['blur'] ? $customization['blur.'.($configurations['blur'] === true ? 'sm' : $configurations['blur'])] : '') => (bool) $configurations['blur']])></div>
     <div x-show="show"
          x-on:click.self="close()"
          x-on:keydown.escape.window="close()"

--- a/src/resources/views/components/modal/main.blade.php
+++ b/src/resources/views/components/modal/main.blade.php
@@ -27,7 +27,7 @@
          x-transition:leave-start="opacity-100"
          x-transition:leave-end="opacity-0"
             @endif
-            @class([$customization['wrapper.first'], $customization['blur.'.($configurations['blur'] === true ? 'sm' : $configurations['blur'])] ?? null => $configurations['blur']])></div>
+            @class([$customization['wrapper.first'], ($configurations['blur'] ? $customization['blur.'.($configurations['blur'] === true ? 'sm' : $configurations['blur'])] : '') => (bool) $configurations['blur']])></div>
     <div class="{{ $customization['wrapper.second'] }}">
         <div @class([
                 $customization['wrapper.third'],

--- a/src/resources/views/components/slide/main.blade.php
+++ b/src/resources/views/components/slide/main.blade.php
@@ -23,7 +23,7 @@
          x-transition:leave-start="opacity-100"
          x-transition:leave-end="opacity-0"
             @endif
-            @class([$customization['wrapper.first'], $customization['blur.'.($configurations['blur'] === true ? 'sm' : $configurations['blur'])] ?? null => $configurations['blur']])></div>
+            @class([$customization['wrapper.first'], ($configurations['blur'] ? $customization['blur.'.($configurations['blur'] === true ? 'sm' : $configurations['blur'])] : '') => (bool) $configurations['blur']])></div>
     <div class="{{ $customization['wrapper.second'] }}">
         <div class="{{ $customization['wrapper.third'] }}">
             <div @class([


### PR DESCRIPTION
## Summary
- When the `blur` property is not set (default `null`), the `@class` directive in modal, slide, and command-palette components uses `null` as an array key, triggering a PHP deprecation warning: *"Using null as an array offset is deprecated, use an empty string instead"*
- This happens because `$customization['blur.'.$configurations['blur']] ?? null` resolves to `null => $configurations['blur']` when blur is falsy
- Fixed by guarding the lookup with a ternary that falls back to an empty string instead of `null`

Affected components:
- `modal/main.blade.php`
- `slide/main.blade.php`
- `command-palette/main.blade.php`