### PR TITLE
fix(date): clear input value when model is reset to null

### DIFF
--- a/src/Components/Form/Date/BrowserTest.php
+++ b/src/Components/Form/Date/BrowserTest.php
@@ -990,4 +990,31 @@ class BrowserTest extends BrowserTestCase
         })
             ->assertSee('[TallStackUI] Form\Date: The start date in the [range] must be greater than the second date.');
     }
+
+    #[Test]
+    public function clears_input_when_model_is_reset_to_null(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public ?string $date = '2020-01-01';
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <p dusk="date">{{ $date ?? 'empty' }}</p>
+
+                    <button type="button" dusk="reset" wire:click="$set('date', null)">Reset</button>
+
+                    <x-date label="DatePicker" wire:model.live="date" />
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->assertInputValue('@tallstackui_date_input', '2020-01-01')
+            ->click('@reset')
+            ->waitForTextIn('@date', 'empty')
+            ->assertInputValue('@tallstackui_date_input', '');
+    }
 }

--- a/src/Components/Form/Date/alpine.js
+++ b/src/Components/Form/Date/alpine.js
@@ -179,7 +179,11 @@ export default (
    * @return {void}
    */
   sync() {
-    if (!this.model) return;
+    if (!this.model) {
+      this.input = '';
+
+      return;
+    }
 
     this.$el.dispatchEvent(
       new CustomEvent('select', { detail: { type: this.type, date: this.model } })


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

When a `wire:model` bound property on `<x-date>` is reset to `null` after the
component has been hydrated with a value, the visible input keeps the previous
value while the Alpine `model` is already `null`.

Cause: in `sync()`, the early `if (!this.model) return;` skips the assignment to
`this.input`, so `$refs.input.value` is never cleared.

Set the input to an empty string before the early return so the DOM follows the
model state. Other branches of `sync()` already write `this.input` themselves;
no behavior changes for those.

Reproduces in real-world flows where a parent Livewire component calls
`reset()` on a form that contains a `<x-date>`. Server-side state is `null`
afterwards, but the date input still shows the previous date.

### Demonstration & Notes:

A new browser test `clears_input_when_model_is_reset_to_null` covers the
scenario:

- Boot with `date = '2020-01-01'`
- Click a button that sets the property to `null`
- Assert `@tallstackui_date_input` value is empty