### PR TITLE
feat(form/error): reactive validation messages via $wire.$errors

### DIFF
--- a/src/Components/Form/Error/FeatureTest.php
+++ b/src/Components/Form/Error/FeatureTest.php
@@ -27,3 +27,29 @@ it('can render with validation error', function () {
         ->toContain('text-red-500')
         ->toContain('The name field is required.');
 });
+
+it('exposes a reactive alpine binding when an error is present', function () {
+    $bag = new MessageBag(['email' => 'Invalid email.']);
+    $errors = new ViewErrorBag;
+    $errors->put('default', $bag);
+
+    View::share('errors', $errors);
+
+    expect('<x-error property="email" />')
+        ->render()
+        ->toContain('$wire?.$errors?.has')
+        ->toContain('$wire?.$errors?.first')
+        ->toContain("'email'");
+});
+
+it('embeds the server-side message as the alpine fallback for non-livewire usage', function () {
+    $bag = new MessageBag(['email' => 'Invalid email.']);
+    $errors = new ViewErrorBag;
+    $errors->put('default', $bag);
+
+    View::share('errors', $errors);
+
+    expect('<x-error property="email" />')
+        ->render()
+        ->toContain('Invalid email.');
+});

--- a/src/resources/views/components/form/error.blade.php
+++ b/src/resources/views/components/form/error.blade.php
@@ -3,7 +3,13 @@
 @endphp
 
 @error ($property)
-<span class="{{ $customization['text'] }}">
-        {{ $message }}
-    </span>
+    <span
+        class="{{ $customization['text'] }}"
+        x-show="typeof $wire?.$errors?.has === 'function'
+            ? $wire.$errors.has('{{ $property }}')
+            : true"
+        x-text="typeof $wire?.$errors?.first === 'function'
+            ? ($wire.$errors.first('{{ $property }}') ?? '')
+            : @js($message)"
+    >{{ $message }}</span>
 @enderror


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

### What:

- [ ] Feature
- [x] Enhancements
- [ ] Bugfix

### Description:

Today the form/error component is rendered with `@error` and the visible message
needs a Livewire re-render to update. With this PR the same `@error` block
keeps the server-side fallback, but the rendered span gets Alpine bindings on
top:

- `x-show` reads `\$wire.\$errors.has(property)` when Livewire is in scope,
  otherwise falls through to `true` so the server-rendered message keeps
  showing.
- `x-text` reads `\$wire.\$errors.first(property)`, otherwise falls back to the
  `@js`-encoded server message.

#### Why this matters

- Live validation reflects in the UI without a full Livewire re-render. With
  islands, debounced saves, or unrelated tabs busy, the validation message is
  no longer tied to the next render cycle of the surrounding component.
- Once an error has mounted the span, subsequent live updates can toggle
  visibility and text without any roundtrip beyond the validate call itself.

#### Behavior

- **Livewire context**: `\$wire.\$errors.has(...)` and `\$wire.\$errors.first(...)`
  drive the visible state. As the error bag shifts (server validation, manual
  `addError()` calls, or live-validation passes that drop the error) the span
  updates in place.
- **Non-Livewire context**: `\$wire` is undefined, the typeof guards fall back
  to the rendered message and `x-show="true"`, so plain Blade forms keep
  rendering exactly like today.
- **No JavaScript**: the inner text of the span still contains the server
  message - same as before.

#### Scope

The wrapper templates remain server-gated by `\$error`, so the span only mounts
once the validation bag is populated. Existing browser and feature tests stay
intact. A future iteration could move the mount logic so the span exists from
first render and reacts to *any* live error - happy to discuss if that
direction is welcome.

### Demonstration & Notes:

Feature tests in `src/Components/Form/Error/FeatureTest.php` cover:

- a span without a server error renders nothing (existing behaviour)
- a server error renders the message inline so it survives without JavaScript
- when the span is rendered it exposes `\$wire.\$errors.has` / `\$wire.\$errors.first`
  for Alpine to consume
- the server-side message is embedded as the alpine fallback for non-Livewire
  contexts

Browser-side reactivity (the `x-show` / `x-text` toggling without a re-render)
is intentionally not covered by a dedicated browser test in this PR to keep
the diff minimal - happy to add one if the approach is welcome.