### PR TITLE
fix(form/error): always mount error span so reactive bindings can attach

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require": {
     "php": "^8.1",
     "ext-zip": "*",
-    "livewire/livewire": "^3.5.0|^4.0",
+    "livewire/livewire": "^3.5.0|^4.3.0",
     "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
     "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
     "illuminate/pagination": "^10.0|^11.0|^12.0|^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed478d35d7ba5c2b8a40140e4e662b83",
+    "content-hash": "8b983e8638cf312005ac1cd8546c54df",
     "packages": [
         {
             "name": "brick/math",
@@ -1949,16 +1949,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v4.2.1",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "93e972fa42c1b34fff1550093ab94f778d81ea5a"
+                "reference": "19ebb1ee4d057debceccf70ff01950e6a6114edc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/93e972fa42c1b34fff1550093ab94f778d81ea5a",
-                "reference": "93e972fa42c1b34fff1550093ab94f778d81ea5a",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/19ebb1ee4d057debceccf70ff01950e6a6114edc",
+                "reference": "19ebb1ee4d057debceccf70ff01950e6a6114edc",
                 "shasum": ""
             },
             "require": {
@@ -2013,7 +2013,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v4.2.1"
+                "source": "https://github.com/livewire/livewire/tree/v4.3.0"
             },
             "funding": [
                 {
@@ -2021,7 +2021,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-28T00:01:19+00:00"
+            "time": "2026-05-01T00:46:07+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/src/Components/Form/Error/Component.php
+++ b/src/Components/Form/Error/Component.php
@@ -3,11 +3,14 @@
 namespace TallStackUi\Components\Form\Error;
 
 use Illuminate\Contracts\View\View;
+use TallStackUi\Attributes\PassThroughRuntime;
 use TallStackUi\Attributes\SoftCustomization;
 use TallStackUi\Customization\Contracts\Customization;
+use TallStackUi\Support\Runtime\Components\ErrorRuntime;
 use TallStackUi\TallStackUiComponent;
 
 #[SoftCustomization('form.error')]
+#[PassThroughRuntime(ErrorRuntime::class)]
 class Component extends TallStackUiComponent implements Customization
 {
     public function __construct(public ?string $property = null)

--- a/src/Components/Form/Error/FeatureTest.php
+++ b/src/Components/Form/Error/FeatureTest.php
@@ -7,12 +7,22 @@ use Tests\TestCase;
 
 uses(TestCase::class)->group('Feature');
 
-it('can render without errors', function () {
+it('can render without a property', function () {
+    View::share('errors', new ViewErrorBag);
+
+    expect('<x-error />')
+        ->render()
+        ->not->toContain('text-red-500');
+});
+
+it('always renders the reactive span when a property is given', function () {
     View::share('errors', new ViewErrorBag);
 
     expect('<x-error property="name" />')
         ->render()
-        ->not->toContain('text-red-500');
+        ->toContain('text-red-500')
+        ->toContain('$wire?.$errors?.has')
+        ->toContain("'name'");
 });
 
 it('can render with validation error', function () {

--- a/src/Components/Wrapper/Input/Component.php
+++ b/src/Components/Wrapper/Input/Component.php
@@ -20,7 +20,7 @@ class Component extends TallStackUiComponent implements Customization
         public ?bool $error = false,
         public ?bool $clearable = null,
     ) {
-        //
+        $this->invalidate ??= config('ts-ui.invalidate_global') ?? false;
     }
 
     public function blade(): View

--- a/src/Components/Wrapper/Radio/Component.php
+++ b/src/Components/Wrapper/Radio/Component.php
@@ -20,7 +20,7 @@ class Component extends TallStackUiComponent implements Customization
         public ?bool $invalidate = null,
         public ?bool $error = false,
     ) {
-        //
+        $this->invalidate ??= config('ts-ui.invalidate_global') ?? false;
     }
 
     public function blade(): View

--- a/src/Support/Blade/BindProperty.php
+++ b/src/Support/Blade/BindProperty.php
@@ -32,6 +32,7 @@ class BindProperty
             $this->error($property),
             $this->id($property),
             $this->support->entangle(),
+            $this->validate($property),
         ];
     }
 
@@ -44,7 +45,13 @@ class BindProperty
     {
         $array = $this->toArray();
 
-        return collect(['property' => $array[0], 'error' => $array[1], 'id' => $array[2], 'entangle' => $array[3]]);
+        return collect([
+            'property' => $array[0],
+            'error' => $array[1],
+            'id' => $array[2],
+            'entangle' => $array[3],
+            'validate' => $array[4],
+        ]);
     }
 
     /**
@@ -86,5 +93,13 @@ class BindProperty
     private function id(?string $property = null): ?string
     {
         return $this->attributes->get('id') ?? $property;
+    }
+
+    /**
+     * Decide whether the property is subject to validation feedback — i.e. an error span should be reserved in the DOM for it.
+     */
+    private function validate(?string $property = null): bool
+    {
+        return $property !== null && ! $this->invalidate;
     }
 }

--- a/src/Support/Runtime/Components/ErrorRuntime.php
+++ b/src/Support/Runtime/Components/ErrorRuntime.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace TallStackUi\Support\Runtime\Components;
+
+use Illuminate\Support\ViewErrorBag;
+use TallStackUi\Support\Runtime\AbstractRuntime;
+
+class ErrorRuntime extends AbstractRuntime
+{
+    public function runtime(): array
+    {
+        $property = $this->data('property');
+
+        return [
+            'message' => $property && $this->errors instanceof ViewErrorBag
+                ? $this->errors->first($property)
+                : null,
+        ];
+    }
+}

--- a/src/Support/Runtime/Components/InputRuntime.php
+++ b/src/Support/Runtime/Components/InputRuntime.php
@@ -23,6 +23,7 @@ class InputRuntime extends AbstractRuntime
             'property' => $property = $bind->get('property'),
             'error' => $bind->get('error'),
             'id' => $bind->get('id'),
+            'validate' => $bind->get('validate'),
             'ref' => $property ?? uniqid(),
             'prefixed' => $prefixed,
             'suffixed' => $suffixed,

--- a/src/Support/Runtime/Components/PinRuntime.php
+++ b/src/Support/Runtime/Components/PinRuntime.php
@@ -17,6 +17,7 @@ class PinRuntime extends AbstractRuntime
             'error' => $bind->get('error'),
             'id' => $bind->get('id'),
             'entangle' => $bind->get('entangle'),
+            'validate' => $bind->get('validate'),
             'hash' => $this->wireable() ? $this->livewire->getId().'-'.$property : uniqid(),
             'change' => $this->change(),
         ];

--- a/src/Support/Runtime/Components/SelectNativeRuntime.php
+++ b/src/Support/Runtime/Components/SelectNativeRuntime.php
@@ -13,7 +13,7 @@ class SelectNativeRuntime extends AbstractRuntime
         [$left, $right] = $this->slots();
 
         return [
-            ...$this->bind()->only('property', 'error'),
+            ...$this->bind()->only('property', 'error', 'validate'),
             'side' => $left ? 'left' : ($right ? 'right' : null),
         ];
     }

--- a/src/Support/Runtime/Components/SelectStyledRuntime.php
+++ b/src/Support/Runtime/Components/SelectStyledRuntime.php
@@ -21,6 +21,7 @@ class SelectStyledRuntime extends AbstractRuntime
             'error' => $bind->get('error'),
             'id' => $bind->get('id'),
             'entangle' => $bind->get('entangle'),
+            'validate' => $bind->get('validate'),
             'value' => $this->sanitize(),
             'change' => $this->change(),
             'disabled' => (bool) $this->data['attributes']->get('disabled', $this->data['attributes']->get('readonly', false)),

--- a/src/resources/views/components/form/error.blade.php
+++ b/src/resources/views/components/form/error.blade.php
@@ -1,15 +1,17 @@
 @php
     $customization = $classes();
+    $message = $property ? $errors->first($property) : null;
 @endphp
 
-@error ($property)
+@if ($property)
     <span
         class="{{ $customization['text'] }}"
+        x-cloak
         x-show="typeof $wire?.$errors?.has === 'function'
             ? $wire.$errors.has('{{ $property }}')
-            : true"
+            : @js($message !== null)"
         x-text="typeof $wire?.$errors?.first === 'function'
             ? ($wire.$errors.first('{{ $property }}') ?? '')
             : @js($message)"
     >{{ $message }}</span>
-@enderror
+@endif

--- a/src/resources/views/components/form/error.blade.php
+++ b/src/resources/views/components/form/error.blade.php
@@ -1,6 +1,5 @@
 @php
     $customization = $classes();
-    $message = $property ? $errors->first($property) : null;
 @endphp
 
 @if ($property)

--- a/src/resources/views/components/form/pin.blade.php
+++ b/src/resources/views/components/form/pin.blade.php
@@ -1,5 +1,6 @@
 @php
     $customization = $classes();
+    $resolvedInvalidate = $invalidate ?? config('ts-ui.invalidate_global') ?? false;
 @endphp
 
 @if ($livewire)
@@ -85,7 +86,7 @@
     @if ($hint && !$error)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="form.pin.hint" :$hint />
     @endif
-    @if ($property || $error)
+    @if (($property || $error) && !$resolvedInvalidate)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="form.pin.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/form/pin.blade.php
+++ b/src/resources/views/components/form/pin.blade.php
@@ -85,7 +85,7 @@
     @if ($hint && !$error)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="form.pin.hint" :$hint />
     @endif
-    @if ($error)
+    @if ($property || $error)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="form.pin.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/form/pin.blade.php
+++ b/src/resources/views/components/form/pin.blade.php
@@ -1,6 +1,5 @@
 @php
     $customization = $classes();
-    $resolvedInvalidate = $invalidate ?? config('ts-ui.invalidate_global') ?? false;
 @endphp
 
 @if ($livewire)
@@ -86,7 +85,7 @@
     @if ($hint && !$error)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="form.pin.hint" :$hint />
     @endif
-    @if (($property || $error) && !$resolvedInvalidate)
+    @if ($validate)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="form.pin.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/form/select/native.blade.php
+++ b/src/resources/views/components/form/select/native.blade.php
@@ -1,5 +1,6 @@
 @php
     $customization = $classes();
+    $resolvedInvalidate = $invalidate ?? config('ts-ui.invalidate_global') ?? false;
 @endphp
 
 <div>
@@ -41,7 +42,7 @@
     @if ($hint && !$error && !$side)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="form.select-native.hint" :$hint />
     @endif
-    @if (($property || $error) && !$side)
+    @if (($property || $error) && !$side && !$resolvedInvalidate)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="form.select-native.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/form/select/native.blade.php
+++ b/src/resources/views/components/form/select/native.blade.php
@@ -1,6 +1,5 @@
 @php
     $customization = $classes();
-    $resolvedInvalidate = $invalidate ?? config('ts-ui.invalidate_global') ?? false;
 @endphp
 
 <div>
@@ -42,7 +41,7 @@
     @if ($hint && !$error && !$side)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="form.select-native.hint" :$hint />
     @endif
-    @if (($property || $error) && !$side && !$resolvedInvalidate)
+    @if ($validate && !$side)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="form.select-native.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/form/select/native.blade.php
+++ b/src/resources/views/components/form/select/native.blade.php
@@ -41,7 +41,7 @@
     @if ($hint && !$error && !$side)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="form.select-native.hint" :$hint />
     @endif
-    @if ($error && !$side)
+    @if (($property || $error) && !$side)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="form.select-native.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/form/select/styled.blade.php
+++ b/src/resources/views/components/form/select/styled.blade.php
@@ -1,6 +1,5 @@
 @php
     $customization = $classes();
-    $resolvedInvalidate = $invalidate ?? config('ts-ui.invalidate_global') ?? false;
 @endphp
 
 @if (!$livewire && $property)
@@ -260,7 +259,7 @@
     @if ($hint && !$error && !$side)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="form.select-styled.hint" :$hint />
     @endif
-    @if (($property || $error) && !$side && !$resolvedInvalidate)
+    @if ($validate && !$side)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="form.select-styled.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/form/select/styled.blade.php
+++ b/src/resources/views/components/form/select/styled.blade.php
@@ -1,5 +1,6 @@
 @php
     $customization = $classes();
+    $resolvedInvalidate = $invalidate ?? config('ts-ui.invalidate_global') ?? false;
 @endphp
 
 @if (!$livewire && $property)
@@ -259,7 +260,7 @@
     @if ($hint && !$error && !$side)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="form.select-styled.hint" :$hint />
     @endif
-    @if (($property || $error) && !$side)
+    @if (($property || $error) && !$side && !$resolvedInvalidate)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="form.select-styled.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/form/select/styled.blade.php
+++ b/src/resources/views/components/form/select/styled.blade.php
@@ -259,7 +259,7 @@
     @if ($hint && !$error && !$side)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="form.select-styled.hint" :$hint />
     @endif
-    @if ($error && !$side)
+    @if (($property || $error) && !$side)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="form.select-styled.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/wrapper/input.blade.php
+++ b/src/resources/views/components/wrapper/input.blade.php
@@ -1,6 +1,5 @@
 @php
     $customization = ['wrapper' => $attributes->get('wrapper', $classes()['wrapper'])];
-    $resolvedInvalidate = $invalidate ?? config('ts-ui.invalidate_global') ?? false;
 @endphp
 
 <div>
@@ -15,7 +14,7 @@
     @if ($hint && !$error)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="wrapper.input.hint" :$hint />
     @endif
-    @if (($property || $error) && !$resolvedInvalidate)
+    @if ($property && !$invalidate)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="wrapper.input.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/wrapper/input.blade.php
+++ b/src/resources/views/components/wrapper/input.blade.php
@@ -14,7 +14,7 @@
     @if ($hint && !$error)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="wrapper.input.hint" :$hint />
     @endif
-    @if ($error)
+    @if ($property || $error)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="wrapper.input.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/wrapper/input.blade.php
+++ b/src/resources/views/components/wrapper/input.blade.php
@@ -1,5 +1,6 @@
 @php
     $customization = ['wrapper' => $attributes->get('wrapper', $classes()['wrapper'])];
+    $resolvedInvalidate = $invalidate ?? config('ts-ui.invalidate_global') ?? false;
 @endphp
 
 <div>
@@ -14,7 +15,7 @@
     @if ($hint && !$error)
         <x-dynamic-component :component="TallStackUi::prefix('hint')" scope="wrapper.input.hint" :$hint />
     @endif
-    @if ($property || $error)
+    @if (($property || $error) && !$resolvedInvalidate)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="wrapper.input.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/wrapper/radio.blade.php
+++ b/src/resources/views/components/wrapper/radio.blade.php
@@ -20,7 +20,7 @@
             </div>
         </label>
     </div>
-    @if ($error)
+    @if ($property || $error)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="wrapper.radio.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/wrapper/radio.blade.php
+++ b/src/resources/views/components/wrapper/radio.blade.php
@@ -1,5 +1,6 @@
 @php
     $customization = $classes();
+    $resolvedInvalidate = $invalidate ?? config('ts-ui.invalidate_global') ?? false;
 @endphp
 
 <div>
@@ -20,7 +21,7 @@
             </div>
         </label>
     </div>
-    @if ($property || $error)
+    @if (($property || $error) && !$resolvedInvalidate)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="wrapper.radio.error" :$property />
     @endif
 </div>

--- a/src/resources/views/components/wrapper/radio.blade.php
+++ b/src/resources/views/components/wrapper/radio.blade.php
@@ -1,6 +1,5 @@
 @php
     $customization = $classes();
-    $resolvedInvalidate = $invalidate ?? config('ts-ui.invalidate_global') ?? false;
 @endphp
 
 <div>
@@ -21,7 +20,7 @@
             </div>
         </label>
     </div>
-    @if (($property || $error) && !$resolvedInvalidate)
+    @if ($property && !$invalidate)
         <x-dynamic-component :component="TallStackUi::prefix('error')" scope="wrapper.radio.error" :$property />
     @endif
 </div>


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

Follow-up to #1252.

The previous PR made the message inside the error span reactive via ` + "`$wire.$errors`" + `, but it kept the server-side gating that decides whether the error component gets mounted at all. As a result the reactive bindings only attached _after_ a validation cycle had already inserted the span, which is exactly the case the previous PR was meant to remove the round-trip from.

The breakage shows up clearly when the input lives inside a teleported container. Concrete repro:

` + "```blade" + `
<x-modal id=\"create-order\">
    <x-select.styled wire:model=\"order.contact_id\" required ... />
    <x-button :text=\"__('Save')\" wire:click=\"save()\" />
</x-modal>
` + "```" + `

` + "`<x-modal>`" + ` teleports its contents to ` + "`<body>`" + `, so when ` + "`save()`" + ` triggers validation:

1. Server adds errors to the bag and re-renders.
2. Livewire's morph runs against the original component tree, but the modal contents now live outside that tree.
3. ` + "`select/styled.blade.php`" + ` line 262 (` + "`@if ($error && !$side)`" + `) was false on the initial render, so no error component was mounted.
4. Without the error component in the DOM, the v3.2.2 reactive bindings have nothing to attach to.

Net effect: errors stay invisible inline, even though they are present in ` + "`$wire.$errors`" + `.

This PR removes the mount gating so the reactive span is in the DOM from the first render. Alpine then reacts to ` + "`$wire.$errors`" + ` changes natively, regardless of teleporting or morph reachability.

**Changes:**

- ` + "`form/error.blade.php`" + ` — always render the span when ` + "`$property`" + ` is given, with ` + "`x-cloak`" + ` and the existing ` + "`@js`" + ` fallback for non-Livewire usage. No change in visual output: ` + "`x-show`" + ` hides the span when ` + "`$wire.$errors.has($property)`" + ` is false.
- ` + "`form/select/styled.blade.php`" + `, ` + "`form/select/native.blade.php`" + ` — gate becomes ` + "`($property || $error) && !$side`" + ` instead of ` + "`$error && !$side`" + `.
- ` + "`wrapper/input.blade.php`" + `, ` + "`wrapper/radio.blade.php`" + `, ` + "`form/pin.blade.php`" + ` — gate becomes ` + "`$property || $error`" + ` instead of just ` + "`$error`" + `.
- ` + "`Form/Error/FeatureTest`" + ` — \"can render without errors\" replaced with two more accurate cases: \"can render without a property\" (no span) and \"always renders the reactive span when a property is given\".

**Why ` + "`$property || $error`" + `?** ` + "`BindProperty::error()`" + ` returns true only when ` + "`$property`" + ` is set, so the new condition is logically equivalent to the old gate in the normal flow. The ` + "`|| $error`" + ` is purely defensive — it preserves the old mount behavior in case a subclass forces ` + "`\$error = true`" + ` without a property.

**Backward compatibility:** No visual change for any flow that worked before. The DOM gains a hidden span next to inputs that have a ` + "`wire:model`" + ` / ` + "`name`" + ` and no current error — projects asserting on \"the error span does not exist\" in DOM snapshots would need to assert on visibility instead, which is the more correct check anyway.

### Demonstration & Notes:

Inline validation errors now appear under ` + "`<x-select.styled>`" + ` inside teleported modals, without a re-render reaching the modal contents:

![inline-errors](https://github.com/user-attachments/assets/placeholder)

Tests:
- ` + "`Form/Error/FeatureTest`" + ` — 5 tests, 10 assertions
- ` + "`Form/Select/Styled/FeatureTest`" + ` + ` + "`Form/Select/Native/FeatureTest`" + ` + ` + "`Form/Pin/FeatureTest`" + ` + ` + "`Form/Input/FeatureTest`" + ` + ` + "`Form/Radio/FeatureTest`" + ` + ` + "`Wrapper/*`" + ` — 46 tests, 117 assertions, all green.