### PR TITLE
feat(command-palette): add overlay opt-out

### DIFF
--- a/src/Components/CommandPalette/Component.php
+++ b/src/Components/CommandPalette/Component.php
@@ -31,6 +31,7 @@ class Component extends TallStackUiComponent implements Customization
         public ?bool $recycle = null,
         public ?string $shortcut = null,
         public ?bool $centered = null,
+        public ?bool $overlay = null,
         #[SkipDebug]
         public ?bool $grouped = null,
         #[SkipDebug]

--- a/src/Support/Configurations/CompileConfigurations.php
+++ b/src/Support/Configurations/CompileConfigurations.php
@@ -87,6 +87,7 @@ class CompileConfigurations
         $component->recycle ??= $configuration['recycle'] ?? true;
         $component->shortcut ??= $configuration['shortcut'] ?? 'ctrl.k';
         $component->centered ??= $configuration['centered'] ?? false;
+        $component->overlay ??= $configuration['overlay'] ?? true;
 
         return [
             'url' => $actionable ? URL::signedRoute('tallstackui.command-palette.action') : null,
@@ -98,6 +99,7 @@ class CompileConfigurations
             'elements' => $configuration['elements'] ?? true,
             'scrollbar' => $configuration['scrollbar'] ?? true,
             'centered' => $component->centered,
+            'overlay' => $component->overlay,
         ];
     }
 

--- a/src/config.php
+++ b/src/config.php
@@ -152,6 +152,7 @@ return [
             | elements: when true, shows the keyboard hints in the footer.
             | scrollbar: when true, applies a custom minimal scrollbar to the results list.
             | centered: when true, centers the palette vertically on mobile with fully rounded corners.
+            | overlay: when false, hides the dimmed background overlay rendered behind the palette.
             */
             [
                 'actionable' => null,
@@ -164,6 +165,7 @@ return [
                 'elements' => true,
                 'scrollbar' => true,
                 'centered' => false,
+                'overlay' => true,
             ],
         ],
         'currency' => Components\Form\Currency\Component::class,

--- a/src/resources/views/components/command-palette/main.blade.php
+++ b/src/resources/views/components/command-palette/main.blade.php
@@ -7,16 +7,18 @@
      x-on:command-palette:{{ $open }}.window="open()"
      x-on:command-palette:{{ $close }}.window="close()"
      {{ $attributes->whereStartsWith('x-on:') }}>
-    <div x-show="show"
-         @if (!$ts_ui__flash)
-             x-transition:enter="ease-out duration-200"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="ease-in duration-150"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-         @endif
-         @class([$customization['backdrop'], $configurations['zIndex'], ($configurations['blur'] ? $customization['blur.'.($configurations['blur'] === true ? 'sm' : $configurations['blur'])] : '') => (bool) $configurations['blur']])></div>
+    @if ($configurations['overlay'])
+        <div x-show="show"
+             @if (!$ts_ui__flash)
+                 x-transition:enter="ease-out duration-200"
+                 x-transition:enter-start="opacity-0"
+                 x-transition:enter-end="opacity-100"
+                 x-transition:leave="ease-in duration-150"
+                 x-transition:leave-start="opacity-100"
+                 x-transition:leave-end="opacity-0"
+             @endif
+             @class([$customization['backdrop'], $configurations['zIndex'], ($configurations['blur'] ? $customization['blur.'.($configurations['blur'] === true ? 'sm' : $configurations['blur'])] : '') => (bool) $configurations['blur']])></div>
+    @endif
     <div x-show="show"
          x-on:click.self="close()"
          x-on:keydown.escape.window="close()"


### PR DESCRIPTION
## Summary

- Adds a new `overlay` boolean prop (default `true`) to the Command Palette component, plus a matching `overlay` key in the component config.
- When set to `false`, the dimmed background overlay rendered behind the palette is skipped, leaving the palette floating above the page without darkening the surrounding UI.
- Backwards compatible: existing usages keep the current behavior since the default remains `true`.

## Usage

```blade
{{-- Default: dimmed overlay rendered behind the palette --}}
<x-command-palette request="..." />

{{-- Opt-out: palette floats with no background dimming --}}
<x-command-palette request="..." :overlay="false" />
```

Or globally via `config/tallstackui.php`:

```php
'command-palette' => [
    // ...
    'overlay' => false,
],
```

## Test plan

- [x] `npm run build` — compiles without errors.
- [x] `./vendor/bin/pint --test --parallel` — passes.
- [x] `./vendor/bin/phpstan analyse --memory-limit=2G` — no errors.
- [x] Manually validated in the playground with two side-by-side palettes (one with overlay, one with `:overlay="false"`).