### PR TITLE
fix(date,calendar): add missing cursor-pointer on clickable buttons

### DIFF
--- a/src/Components/Calendar/Component.php
+++ b/src/Components/Calendar/Component.php
@@ -100,7 +100,7 @@ class Component extends TallStackUiComponent implements Customization
                 'select' => 'text-gray-600 dark:text-dark-400 hover:bg-dark-200 dark:hover:bg-dark-600',
                 'today' => 'text-primary-500 dark:text-dark-300! font-bold!',
                 'selected' => 'bg-primary-500 text-white! hover:bg-primary-500/75',
-                'helpers' => 'text-gray-500 dark:text-dark-300 bg-dark-200 dark:bg-dark-600 hover:bg-dark-300 dark:hover:bg-dark-500 select-none whitespace-nowrap rounded-md px-2 py-1 text-sm font-medium',
+                'helpers' => 'text-gray-500 dark:text-dark-300 bg-dark-200 dark:bg-dark-600 hover:bg-dark-300 dark:hover:bg-dark-500 select-none whitespace-nowrap rounded-md px-2 py-1 text-sm font-medium cursor-pointer',
                 'navigate' => 'focus:shadow-outline hover:bg-dark-100 dark:hover:bg-dark-600 inline-flex cursor-pointer rounded-full p-1 transition duration-100 ease-in-out focus:outline-hidden',
             ],
             'icon' => [

--- a/src/Components/Form/Date/Component.php
+++ b/src/Components/Form/Date/Component.php
@@ -93,7 +93,7 @@ class Component extends TallStackUiComponent implements Customization
                 'select' => 'text-gray-600 dark:text-dark-400 hover:bg-dark-200 dark:hover:bg-dark-600',
                 'today' => 'text-primary-500 dark:text-dark-300 font-bold!',
                 'selected' => 'bg-primary-500 text-white! hover:bg-primary-500/75',
-                'helpers' => 'text-gray-500 dark:text-dark-300 bg-dark-200 dark:bg-dark-600 hover:bg-dark-300 dark:hover:bg-dark-500 select-none whitespace-nowrap rounded-md px-2 py-1 text-sm font-medium',
+                'helpers' => 'text-gray-500 dark:text-dark-300 bg-dark-200 dark:bg-dark-600 hover:bg-dark-300 dark:hover:bg-dark-500 select-none whitespace-nowrap rounded-md px-2 py-1 text-sm font-medium cursor-pointer',
                 'navigate' => 'focus:shadow-outline hover:bg-dark-100 dark:hover:bg-dark-600 inline-flex cursor-pointer rounded-full p-1 transition duration-100 ease-in-out focus:outline-hidden',
             ],
             'icon' => [

--- a/src/resources/views/components/form/date.blade.php
+++ b/src/resources/views/components/form/date.blade.php
@@ -79,7 +79,7 @@
                                 <span x-text="calendar.months[month]"
                                       class="{{ $customization['label.month'] }}"></span>
                             </button>
-                            <button type="button" class="mr-2" x-on:click="now()" x-show="!monthYearOnly">
+                            <button type="button" class="mr-2 cursor-pointer" x-on:click="now()" x-show="!monthYearOnly">
                                 {{ trans('ts-ui::messages.date.helpers.today') }}
                             </button>
                         </div>
@@ -103,7 +103,7 @@
                                 <span class="{{ $customization['box.picker.separator'] }}">-</span>
                                 <span x-text="range.year.last" class="{{ $customization['label.month'] }}"></span>
                             </div>
-                            <button type="button" x-on:click="now()" x-show="!monthYearOnly">
+                            <button type="button" class="cursor-pointer" x-on:click="now()" x-show="!monthYearOnly">
                                 {{ trans('ts-ui::messages.date.helpers.today') }}
                             </button>
                             <div>


### PR DESCRIPTION
## Summary

Audited every clickable element inside the `Form/Date` and `Calendar` components and aligned the missing ones with the rest:

- Helper buttons (`Yesterday` / `Today` / `Tomorrow`) — both Date and Calendar share the `button.helpers` customization key, which was missing `cursor-pointer`.
- Inline "Today" shortcut inside the Date month/year picker (`form/date.blade.php` L82 and L106) — the Date component renders these via inline classes (the Calendar uses `box.picker.today`, which already had `cursor-pointer`).

Everything else (chevron navigation, month/year labels, day cells, month/year picker tiles, clear/open buttons on the input) was already correct.

## Files

- `src/Components/Form/Date/Component.php` — `button.helpers` += `cursor-pointer`
- `src/Components/Calendar/Component.php` — `button.helpers` += `cursor-pointer`
- `src/resources/views/components/form/date.blade.php` — inline `Today` buttons += `cursor-pointer`

## Test plan

- [x] `npm run build` — compiles without errors (no `dist/` regeneration since `cursor-pointer` was already in the Tailwind output).
- [x] `./vendor/bin/pint --test --parallel` — passes.
- [x] `./vendor/bin/phpstan analyse --memory-limit=2G` — no errors.
- [x] Manually validated in the playground: hovered every clickable element on both the Date and the Calendar examples and confirmed the pointer cursor.