### PR TITLE
[3.x] Fixing `modal` Scrollbar Bleeding Past Rounded Corners

### DIFF
--- a/src/Components/Modal/Component.php
+++ b/src/Components/Modal/Component.php
@@ -45,7 +45,7 @@ class Component extends TallStackUiComponent implements Customization
                 'second' => 'fixed inset-0 z-50 w-screen overflow-y-auto',
                 'third' => 'mx-auto flex min-h-full w-full transform justify-center sm:p-4',
                 'fourth' => 'dark:bg-dark-700 relative flex w-full transform flex-col rounded-t-xl sm:rounded-xl bg-white text-left shadow-xl transition-all',
-                'scrollable' => 'max-h-[80vh] flex flex-col',
+                'scrollable' => 'max-h-[80vh] flex flex-col overflow-hidden',
             ],
             'positions' => [
                 'top' => 'items-end sm:items-start',

--- a/src/Components/Modal/FeatureTest.php
+++ b/src/Components/Modal/FeatureTest.php
@@ -56,6 +56,28 @@ it('can thrown exception when size is unnaceptable', function (string $size) {
     '10xl',
 ]);
 
+it('clips overflow on the scrollable wrapper so the scrollbar respects rounded corners', function () {
+    $component = <<<'HTML'
+    <x-modal scrollable>
+    Long content
+    </x-modal>
+    HTML;
+
+    expect($component)->render()
+        ->toContain('max-h-[80vh] flex flex-col overflow-hidden');
+});
+
+it('does not apply overflow-hidden when not scrollable', function () {
+    $component = <<<'HTML'
+    <x-modal>
+    Short content
+    </x-modal>
+    HTML;
+
+    expect($component)->render()
+        ->not->toContain('max-h-[80vh] flex flex-col overflow-hidden');
+});
+
 it('can render centered modal with items-center on all viewports', function () {
     $component = <<<'HTML'
     <x-modal title="Centered" center>


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

The `scrollable` modal variant let the body's native scrollbar bleed past the wrapper's rounded corners when the modal had no `title` and no `footer`. The bug was only visible in that combination because the optional title/footer regions used to mask the corner.

Fix is a single class addition: the `wrapper.scrollable` customization block now includes `overflow-hidden`. This clips any overflow from the inner body to the wrapper's `rounded-xl` shape regardless of which optional regions are present.

No public API change. The `wrapper.scrollable` soft-customization key keeps its name and shape — only the default class string changed.

### Demonstration & Notes:

```blade
<x-modal scrollable>
    {{ $longBody }}
</x-modal>

<x-modal title="Modal title" scrollable>
    {{ $longBody }}
</x-modal>

<x-modal scrollable>
    {{ $longBody }}
    <x-slot:footer>
        <x-button>Confirm</x-button>
    </x-slot:footer>
</x-modal>
```