### PR TITLE
[3.x] Expand `badge` and `environment` Round Prop

### DIFF
--- a/src/Components/Badge/Component.php
+++ b/src/Components/Badge/Component.php
@@ -25,7 +25,7 @@ class Component extends TallStackUiComponent implements Customization
         public ?bool $lg = null,
         public ?string $color = 'primary',
         public ?bool $square = false,
-        public ?bool $round = false,
+        public bool|string|null $round = false,
         public ?bool $solid = true,
         public ?bool $outline = null,
         public ?bool $light = null,
@@ -34,6 +34,8 @@ class Component extends TallStackUiComponent implements Customization
         #[SkipDebug]
         public ?string $style = null,
         #[SkipDebug]
+        public ?string $rounded = null,
+        #[SkipDebug]
         public ?string $left = null,
         #[SkipDebug]
         public ?string $right = null,
@@ -41,6 +43,7 @@ class Component extends TallStackUiComponent implements Customization
         $this->style = $this->outline ? 'outline' : ($this->light ? 'light' : 'solid');
         $this->size = $this->lg ? 'lg' : ($this->md ? 'md' : ($this->sm ? 'sm' : 'xs'));
         $this->position = $this->position === 'right' ? 'right' : 'left';
+        $this->rounded = $this->round === true ? 'full' : (is_string($this->round) ? $this->round : 'md');
     }
 
     public function blade(): View
@@ -63,9 +66,26 @@ class Component extends TallStackUiComponent implements Customization
             'clickable' => 'cursor-pointer',
             'icon' => 'h-3 w-3',
             'border.radius' => [
-                'rounded' => 'rounded-md',
-                'circle' => 'rounded-full',
+                'xs' => 'rounded-xs',
+                'sm' => 'rounded-sm',
+                'md' => 'rounded-md',
+                'lg' => 'rounded-lg',
+                'xl' => 'rounded-xl',
+                'full' => 'rounded-full',
             ],
         ]);
+    }
+
+    protected function validate(): void
+    {
+        if (! is_string($this->round)) {
+            return;
+        }
+
+        $sizes = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+        if (! in_array($this->round, $sizes, true)) {
+            __ts_validation_exception($this, 'The [round] must be true or one of: ['.implode(', ', $sizes).'].');
+        }
     }
 }

--- a/src/Components/Badge/FeatureTest.php
+++ b/src/Components/Badge/FeatureTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\View\ViewException;
 use Tests\TestCase;
 
 uses(TestCase::class)->group('Feature');
@@ -28,6 +29,26 @@ it('can render round')
     ->toContain('Foo bar')
     ->toContain('rounded-full')
     ->not->toContain('rounded-md');
+
+it('can render round with named size', function (string $size, string $class) {
+    $component = "<x-badge round=\"$size\">Foo bar</x-badge>";
+
+    expect($component)->render()
+        ->toContain('Foo bar')
+        ->toContain($class);
+})->with([
+    ['xs', 'rounded-xs'],
+    ['sm', 'rounded-sm'],
+    ['md', 'rounded-md'],
+    ['lg', 'rounded-lg'],
+    ['xl', 'rounded-xl'],
+]);
+
+it('cannot accept invalid round value', function () {
+    $this->expectException(ViewException::class);
+
+    expect('<x-badge round="huge">Foo bar</x-badge>')->render();
+});
 
 it('can render size variations', function (array $size) {
     $key = array_key_first($size);

--- a/src/Components/Environment/Component.php
+++ b/src/Components/Environment/Component.php
@@ -23,12 +23,14 @@ class Component extends TallStackUiComponent implements Customization
         public ?bool $md = null,
         public ?bool $lg = null,
         public ?bool $square = false,
-        public ?bool $round = false,
+        public bool|string|null $round = false,
         public ?bool $withoutBranch = null,
         #[SkipDebug]
         public ?string $branch = null,
         #[SkipDebug]
         public ?string $size = null,
+        #[SkipDebug]
+        public ?string $rounded = null,
         #[SkipDebug]
         public ComponentSlot|string|null $left = null,
         #[SkipDebug]
@@ -36,6 +38,7 @@ class Component extends TallStackUiComponent implements Customization
     ) {
         $this->branch = $this->branch();
         $this->size = $this->lg ? 'lg' : ($this->md ? 'md' : ($this->sm ? 'sm' : 'xs'));
+        $this->rounded = $this->round === true ? 'full' : (is_string($this->round) ? $this->round : 'md');
     }
 
     public function blade(): View
@@ -55,7 +58,28 @@ class Component extends TallStackUiComponent implements Customization
                     'lg' => 'text-lg',
                 ],
             ],
+            'border.radius' => [
+                'xs' => 'rounded-xs',
+                'sm' => 'rounded-sm',
+                'md' => 'rounded-md',
+                'lg' => 'rounded-lg',
+                'xl' => 'rounded-xl',
+                'full' => 'rounded-full',
+            ],
         ]);
+    }
+
+    protected function validate(): void
+    {
+        if (! is_string($this->round)) {
+            return;
+        }
+
+        $sizes = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+        if (! in_array($this->round, $sizes, true)) {
+            __ts_validation_exception($this, 'The [round] must be true or one of: ['.implode(', ', $sizes).'].');
+        }
     }
 
     private function branch(): ?string

--- a/src/Components/Environment/FeatureTest.php
+++ b/src/Components/Environment/FeatureTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\View\ViewException;
 use Tests\TestCase;
 
 uses(TestCase::class)->group('Feature');
@@ -8,6 +9,36 @@ it('can render')
     ->expect('<x-environment />')
     ->render()
     ->toContain('Environment:');
+
+it('can render square')
+    ->expect('<x-environment square />')
+    ->render()
+    ->not->toContain('rounded-md')
+    ->not->toContain('rounded-full');
+
+it('can render round')
+    ->expect('<x-environment round />')
+    ->render()
+    ->toContain('rounded-full')
+    ->not->toContain('rounded-md');
+
+it('can render round with named size', function (string $size, string $class) {
+    $component = "<x-environment round=\"$size\" />";
+
+    expect($component)->render()->toContain($class);
+})->with([
+    ['xs', 'rounded-xs'],
+    ['sm', 'rounded-sm'],
+    ['md', 'rounded-md'],
+    ['lg', 'rounded-lg'],
+    ['xl', 'rounded-xl'],
+]);
+
+it('cannot accept invalid round value', function () {
+    $this->expectException(ViewException::class);
+
+    expect('<x-environment round="huge" />')->render();
+});
 
 it('can render left slot', function () {
     $component = <<<'HTML'

--- a/src/resources/views/components/badge/main.blade.php
+++ b/src/resources/views/components/badge/main.blade.php
@@ -3,8 +3,7 @@
 @endphp
 
 <span {{ $attributes->class([
-        $customization['border.radius.rounded'] => !$round && !$square,
-        $customization['border.radius.circle'] => $round,
+        $customization['border.radius.' . $rounded] => !$square,
         $customization['wrapper.class'],
         $customization['wrapper.sizes.' . $size],
         $colors['background'],

--- a/src/resources/views/components/environment/main.blade.php
+++ b/src/resources/views/components/environment/main.blade.php
@@ -3,8 +3,7 @@
 @endphp
 
 <span {{ $attributes->class([
-        'rounded-md' => !$round && !$square,
-        'rounded-full' => $round,
+        $customization['border.radius.' . $rounded] => !$square,
         $customization['wrapper.class'],
         $customization['wrapper.sizes.' . $size],
         $colors['background'],


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

The `round` prop on `<x-badge>` and `<x-environment>` now accepts Tailwind size keys in addition to the historical boolean form.

- `<x-badge round>` / `<x-environment round>` keeps the previous behavior — applies `rounded-full`.
- `<x-badge round="xs|sm|md|lg|xl">` / `<x-environment round="xs|sm|md|lg|xl">` applies the matching `rounded-{size}` utility.
- Without the prop the components fall back to the default `rounded-md`.
- `square` keeps its existing semantics and still wins over `round`, removing the radius entirely.
- A render-time exception is thrown when `round` is set to a string outside `[xs, sm, md, lg, xl]`.

Customization keys for the radius were renamed in both components:

- `badge.border.radius.rounded` was removed; use `badge.border.radius.md` instead.
- `badge.border.radius.circle` was removed; use `badge.border.radius.full` instead.
- New keys on both `badge` and `environment`: `border.radius.{xs,sm,md,lg,xl,full}`. Previously `environment` had no customizable radius keys (the classes were hardcoded in the blade template); they now exist with the same shape as `badge`.

### Demonstration & Notes:

```blade
<x-badge text="default" />

<x-badge text="full" round />

<x-badge text="xl" round="xl" />

<x-badge text="square" square />

<x-environment round="lg" />

<x-environment round />
```