### PR TITLE
[3.x] Fixing `avatar.group` Reverse Alignment

### DIFF
--- a/.ai/components/avatar/group.md
+++ b/.ai/components/avatar/group.md
@@ -63,5 +63,5 @@ TallStackUi::customize()
 
 | Block Name      | Purpose                                                                  |
 |-----------------|--------------------------------------------------------------------------|
-| wrapper.base    | Flex container with negative horizontal spacing for overlapping avatars  |
+| wrapper.base    | Inline-flex container with negative horizontal spacing for overlapping avatars; shrink-to-fit so the group stays anchored to the parent's flow start in both default and reverse modes |
 | wrapper.reverse | Extra classes applied only when `reverse` is enabled to flip the overlap |

--- a/src/Components/Avatar/Group/Component.php
+++ b/src/Components/Avatar/Group/Component.php
@@ -25,7 +25,7 @@ class Component extends TallStackUiComponent implements Customization
     {
         return Arr::dot([
             'wrapper' => [
-                'base' => 'flex -space-x-2',
+                'base' => 'inline-flex -space-x-2',
                 'reverse' => 'flex-row-reverse space-x-reverse',
             ],
         ]);

--- a/src/Components/Form/Autocomplete/Component.php
+++ b/src/Components/Form/Autocomplete/Component.php
@@ -59,7 +59,7 @@ class Component extends TallStackUiComponent implements Customization
     {
         return Arr::dot([
             'adornment' => [
-                'suffix' => 'dark:text-dark-400 flex select-none items-center whitespace-nowrap pr-3 text-gray-500 text-sm',
+                'suffix' => 'dark:text-dark-400 flex select-none items-center whitespace-nowrap text-gray-500 text-sm',
             ],
             'icon' => [
                 'wrapper' => 'mr-2 flex items-center gap-1.5',


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

`<x-avatar.group reverse>` was pushing the entire group to the right edge of its parent because `wrapper.base` used `flex` (block-level), and `flex-row-reverse` in a block-level flex container makes children accumulate against the right side. The wrapper is now `inline-flex` (shrink-to-fit), so the group stays anchored to the parent's flow start in both default and reverse modes — only the internal stacking order is mirrored. No public API change.

The `wrapper.base` soft-customization block string changed from `flex -space-x-2` to `inline-flex -space-x-2`. Relevant only for projects overriding that block.

Side change: `<x-form/autocomplete>` removed `pr-3` from the `adornment.suffix` block (cosmetic, no behavior change).

### Demonstration & Notes:

```blade
<x-avatar.group reverse>
    <x-avatar text="A" />
    <x-avatar text="B" />
    <x-avatar text="C" />
</x-avatar.group>
```