### PR TITLE
fix(side-bar): correct AI docs component aliases

### DIFF
--- a/.ai/components/layout/sidebar/item.md
+++ b/.ai/components/layout/sidebar/item.md
@@ -10,36 +10,36 @@ A sidebar navigation item component that renders as either a single link or a co
 Single navigation item:
 
 ```blade
-<x-layout.sidebar.item text="Dashboard" route="/dashboard" icon="home" />
+<x-side-bar.item text="Dashboard" route="/dashboard" icon="home" />
 ```
 
 Item with badge:
 
 ```blade
-<x-layout.sidebar.item text="Notifications" route="/notifications" icon="bell">
+<x-side-bar.item text="Notifications" route="/notifications" icon="bell">
     <x-slot:badge>5</x-slot:badge>
-</x-layout.sidebar.item>
+</x-side-bar.item>
 ```
 
 Collapsible group with nested items:
 
 ```blade
-<x-layout.sidebar.item text="Settings" icon="cog-6-tooth" opened>
-    <x-layout.sidebar.item text="General" route="/settings/general" />
-    <x-layout.sidebar.item text="Security" route="/settings/security" />
-</x-layout.sidebar.item>
+<x-side-bar.item text="Settings" icon="cog-6-tooth" opened>
+    <x-side-bar.item text="General" route="/settings/general" />
+    <x-side-bar.item text="Security" route="/settings/security" />
+</x-side-bar.item>
 ```
 
 Marking an item as current manually:
 
 ```blade
-<x-layout.sidebar.item text="Profile" href="/profile" icon="user" current />
+<x-side-bar.item text="Profile" href="/profile" icon="user" current />
 ```
 
 Using route pattern matching:
 
 ```blade
-<x-layout.sidebar.item text="Orders" route="/orders" icon="shopping-cart" match="orders.*" />
+<x-side-bar.item text="Orders" route="/orders" icon="shopping-cart" match="orders.*" />
 ```
 
 ## Attributes
@@ -61,20 +61,20 @@ Using route pattern matching:
 
 | Slot      | Description                                                                     |
 |-----------|---------------------------------------------------------------------------------|
-| (default) | Nested `<x-layout.sidebar.item>` children, making this item a collapsible group |
+| (default) | Nested `<x-side-bar.item>` children, making this item a collapsible group |
 | icon      | Custom icon content instead of a Heroicon name                                  |
 | badge     | Badge content displayed alongside the item text                                 |
 
 ## Inherited Attributes
 
-These attributes are inherited from the parent `<x-layout.sidebar>` via `@aware`:
+These attributes are inherited from the parent `<x-side-bar>` via `@aware`:
 
 | Attribute      | Source                                                                            |
 |----------------|-----------------------------------------------------------------------------------|
-| smart          | `<x-layout.sidebar smart>` enables automatic route-based active state detection   |
-| navigate       | `<x-layout.sidebar navigate>` adds `wire:navigate` to links                       |
-| navigate-hover | `<x-layout.sidebar navigate-hover>` adds `wire:navigate.hover` to links           |
-| collapsible    | `<x-layout.sidebar collapsible>` enables collapsed sidebar behavior with tooltips |
+| smart          | `<x-side-bar smart>` enables automatic route-based active state detection   |
+| navigate       | `<x-side-bar navigate>` adds `wire:navigate` to links                       |
+| navigate-hover | `<x-side-bar navigate-hover>` adds `wire:navigate.hover` to links           |
+| collapsible    | `<x-side-bar collapsible>` enables collapsed sidebar behavior with tooltips |
 
 ## Soft Customization
 

--- a/.ai/components/layout/sidebar/main.md
+++ b/.ai/components/layout/sidebar/main.md
@@ -8,32 +8,32 @@ A responsive sidebar navigation component with mobile slide-out drawer and deskt
 ## Basic Usage
 
 ```blade
-<x-layout.sidebar>
+<x-side-bar>
     <x-slot:brand>
         <div class="flex items-center px-4 py-6">
             <img src="/logo.svg" alt="Logo" class="h-8" />
             <span class="ml-2 font-bold">My App</span>
         </div>
     </x-slot:brand>
-    <x-layout.sidebar.item text="Dashboard" route="/dashboard" icon="home" />
-    <x-layout.sidebar.item text="Settings" route="/settings" icon="cog-6-tooth" />
-</x-layout.sidebar>
+    <x-side-bar.item text="Dashboard" route="/dashboard" icon="home" />
+    <x-side-bar.item text="Settings" route="/settings" icon="cog-6-tooth" />
+</x-side-bar>
 ```
 
 ```blade
-<x-layout.sidebar collapsible navigate thin-scroll>
+<x-side-bar collapsible navigate thin-scroll>
     <x-slot:brand>
         <div class="px-4 py-6"><img src="/logo.svg" class="h-8" /></div>
     </x-slot:brand>
     <x-slot:brand-collapsed>
         <div class="px-2 py-6"><img src="/icon.svg" class="h-8" /></div>
     </x-slot:brand-collapsed>
-    <x-layout.sidebar.separator text="Main" />
-    <x-layout.sidebar.item text="Dashboard" route="/dashboard" icon="home" />
+    <x-side-bar.separator text="Main" />
+    <x-side-bar.item text="Dashboard" route="/dashboard" icon="home" />
     <x-slot:footer>
         <p class="text-sm text-gray-400">v3.0</p>
     </x-slot:footer>
-</x-layout.sidebar>
+</x-side-bar>
 ```
 
 ## Attributes
@@ -54,7 +54,7 @@ A responsive sidebar navigation component with mobile slide-out drawer and deskt
 
 | Slot            | Description                                                                             |
 |-----------------|-----------------------------------------------------------------------------------------|
-| (default)       | Sidebar navigation items (`<x-layout.sidebar.item>` and `<x-layout.sidebar.separator>`) |
+| (default)       | Sidebar navigation items (`<x-side-bar.item>` and `<x-side-bar.separator>`) |
 | brand           | Logo or branding content at the top                                                     |
 | brand-collapsed | Compact branding shown when sidebar is collapsed (requires `collapsible`)               |
 | footer          | Footer content pinned to the bottom of the sidebar                                      |

--- a/.ai/components/layout/sidebar/separator.md
+++ b/.ai/components/layout/sidebar/separator.md
@@ -10,25 +10,25 @@ A sidebar section separator component that visually divides navigation groups. A
 Simple text separator (default):
 
 ```blade
-<x-layout.sidebar.separator text="Main Navigation" />
+<x-side-bar.separator text="Main Navigation" />
 ```
 
 Centered line separator:
 
 ```blade
-<x-layout.sidebar.separator text="Settings" line />
+<x-side-bar.separator text="Settings" line />
 ```
 
 Right-aligned line separator:
 
 ```blade
-<x-layout.sidebar.separator text="Admin" line-right />
+<x-side-bar.separator text="Admin" line-right />
 ```
 
 Using slot content instead of text attribute:
 
 ```blade
-<x-layout.sidebar.separator>General</x-layout.sidebar.separator>
+<x-side-bar.separator>General</x-side-bar.separator>
 ```
 
 ## Attributes
@@ -50,7 +50,7 @@ Using slot content instead of text attribute:
 
 | Attribute   | Source                                                                              |
 |-------------|-------------------------------------------------------------------------------------|
-| collapsible | `<x-layout.sidebar collapsible>` enables visibility transitions for collapsed state |
+| collapsible | `<x-side-bar collapsible>` enables visibility transitions for collapsed state |
 
 ## Soft Customization
 


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [ ] I ensure that the current tests are passing
- [ ] I added tests that prove this pull request is working

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

This PR fixes incorrect sidebar component aliases in TallStackUI AI documentation files.

The files under `.ai/components/layout/sidebar` were documenting sidebar usage with `x-layout.sidebar*`, while the actual registered component aliases in the package config are `x-side-bar*`.

To align AI-oriented docs with runtime behavior and prevent invalid generated code, this PR replaces:

- `<x-layout.sidebar>` -> `<x-side-bar>`
- `<x-layout.sidebar.item>` -> `<x-side-bar.item>`
- `<x-layout.sidebar.separator>` -> `<x-side-bar.separator>`

Updated files:

- `.ai/components/layout/sidebar/main.md`
- `.ai/components/layout/sidebar/item.md`
- `.ai/components/layout/sidebar/separator.md`

Scope is intentionally documentation-only (no runtime/component registration changes), avoiding any breaking change.

### Demonstration & Notes:

Notes:

- This change addresses the specific mismatch: AI docs/examples should reflect real component aliases.
- This prevents agents and developers from using non-existent tags and hitting errors like "Unable to locate a class or view for component".
- No functional code changes were made.
