### PR TITLE
fix(assets): return 404 when requested asset file does not exist

### DIFF
--- a/src/Http/Controllers/TallStackUiAssetsController.php
+++ b/src/Http/Controllers/TallStackUiAssetsController.php
@@ -17,12 +17,20 @@ class TallStackUiAssetsController
     /** @throws Exception */
     public function script(?string $file = null): Response|BinaryFileResponse
     {
-        return Utils::pretendResponseIsFile(self::DIST_PATH.'/'.$file, 'text/javascript');
+        $path = self::DIST_PATH.'/'.$file;
+
+        abort_unless(is_file($path), 404);
+
+        return Utils::pretendResponseIsFile($path, 'text/javascript');
     }
 
     /** @throws Exception */
     public function style(?string $file = null): Response|BinaryFileResponse
     {
-        return Utils::pretendResponseIsFile(self::DIST_PATH.'/'.$file, 'text/css');
+        $path = self::DIST_PATH.'/'.$file;
+
+        abort_unless(is_file($path), 404);
+
+        return Utils::pretendResponseIsFile($path, 'text/css');
     }
 }

--- a/tests/Feature/Structure/AssetsTest.php
+++ b/tests/Feature/Structure/AssetsTest.php
@@ -1,8 +1,31 @@
 <?php
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use TallStackUi\Http\Controllers\TallStackUiAssetsController;
 
 test('contains all methods')
     ->expect(TallStackUiAssetsController::class)
     ->toHaveMethod('script')
     ->toHaveMethod('style');
+
+test('aborts with 404 when the requested script file does not exist', function () {
+    $controller = new TallStackUiAssetsController;
+
+    try {
+        $controller->script('non-existent-chunk-'.uniqid().'.js.map');
+        $this->fail('Expected HttpException was not thrown.');
+    } catch (HttpException $e) {
+        expect($e->getStatusCode())->toBe(404);
+    }
+});
+
+test('aborts with 404 when the requested style file does not exist', function () {
+    $controller = new TallStackUiAssetsController;
+
+    try {
+        $controller->style('non-existent-chunk-'.uniqid().'.css');
+        $this->fail('Expected HttpException was not thrown.');
+    } catch (HttpException $e) {
+        expect($e->getStatusCode())->toBe(404);
+    }
+});


### PR DESCRIPTION
## Summary

`TallStackUiAssetsController::script()` and `style()` forward the requested path directly to Livewire's `Utils::pretendResponseIsFile()`, which calls `filemtime()` on the path. When a stale browser tab requests a hashed asset filename from a previous build (e.g. `chunk-DJhY7h8f.js.map`), the file no longer exists on disk and `filemtime()` raises a PHP warning that gets turned into an `ErrorException`.

Recurring production error in logs/error trackers:

```
filemtime(): stat failed for /vendor/tallstackui/tallstackui/src/Http/Controllers/../../../dist/chunk-DJhY7h8f.js.map
```

This is a normal client-side condition (browser cached HTML referencing an old hashed asset), not an application bug, so it should result in a clean `404` response, not a logged exception.

## Fix

Guard the resolved path with `is_file()` and `abort(404)` before delegating to `Utils::pretendResponseIsFile()`. Matches the `abort_unless()` style already used in `TallStackUiCommandPaletteController`. No other behavior is changed.

A small feature test was added next to the existing `AssetsTest` to cover both `script()` and `style()`.